### PR TITLE
Parallel run + caching 

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -6,6 +6,11 @@ on:
                         - "**.php"
                         - "phpcs.xml"
                         - ".github/workflows/phpcs.yml"
+        push:
+                paths:
+                        - "**.php"
+                        - "phpcs.xml"
+                        - ".github/workflows/phpcs.yml"
 
 jobs:
         phpcs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,13 @@ jobs:
       matrix:
         operating-system: ['ubuntu-latest']
         php-versions: ['7.4']
+        redis-version: [ 4, 5, 6 ]
         phpunit-versions: ['latest']
         include:
           - operating-system: 'ubuntu-latest'
             php-versions: '7.4'
+    env:
+      REDIS_HOST: 127.0.0.1
     steps:
       - uses: actions/checkout@v2
       - uses: nanasess/setup-php@master
@@ -20,6 +23,11 @@ jobs:
         run: sudo composer self-update 1.10.15 --no-interaction
       - name: Run Composer Install
         run: composer install --no-interaction
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.4.0
+        with:
+          redis-version: 6
+          redis-container-name: redis
       - name: run tests
         run: vendor/bin/phpunit
   abrouter-tests-php-80:
@@ -32,6 +40,8 @@ jobs:
         include:
           - operating-system: 'ubuntu-latest'
             php-versions: '8.0'
+    env:
+      REDIS_HOST: 127.0.0.1
     steps:
       - uses: actions/checkout@v2
       - uses: nanasess/setup-php@master
@@ -41,5 +51,10 @@ jobs:
         run: sudo composer self-update 1.10.15 --no-interaction
       - name: Run Composer Install
         run: composer install --no-interaction
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.4.0
+        with:
+          redis-version: 6
+          redis-container-name: redis
       - name: run tests
         run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -58,6 +58,78 @@ echo '<button style="color: '. $branchId .'">Hello</button>';
 
 You can create an experiment and get your token and id of experiment on [ABRouter](https://abrouter.com) or just read the [docs](https://abrouter.com/en/docs). 
 
+##Parallel running
+
+Parallel running is a mode which allows you to run the experiments asynchronous. 
+Main things to make it works are configuring KvStorage and TaskManager. 
+KvStorage and TaskManager are using Redis to store data and tasks.
+ABRouter php client has built-in KvStorage and TaskManager, but you can make your own implementation and replace it via DI and contracts.
+We're highly recommend you to use built-in solution. The implementation is completely tested and works well. Using Parallel running gives you a great growth in speed.
+The config for parallel running is a bit different from the default config.
+
+
+###Configuration
+```php
+use Abrouter\Client\Config\Config;
+use DI\ContainerBuilder;
+use Abrouter\Client\Client;
+use Abrouter\Client\Config\RedisConfig;
+use Abrouter\Client\Contracts\KvStorageContract;
+use Abrouter\Client\DB\RedisConnection;
+use Abrouter\Client\Services\KvStorage\KvStorage;
+use Abrouter\Client\Services\TaskManager\TaskManager;
+        
+require '/app/vendor/autoload.php';
+        
+$containerBuilder = new ContainerBuilder();
+$di = $containerBuilder->build();
+
+
+$redisConfig = new RedisConfig(
+    $_SERVER['REDIS_HOST'] ?? 'redis',
+    6379,
+    '',
+    '',
+    ''
+);
+
+$host = 'https://abrouter.com';
+$token = uniqid();
+
+$config = new Config(
+    $token,
+    $host,
+);
+$config->setRedisConfig($redisConfig);
+$container->set(Config::class, $config);
+
+$kvStorage = $container->make(KvStorage::class);
+$container->make(KvStorage::class);
+$container->set(
+    KvStorageContract::class,
+    $kvStorage
+);
+
+$config->setKvStorageConfig($kvStorage);
+$container->set(Config::class, $config);
+$taskManager = $container->make(TaskManager::class);
+
+$config->setParallelRunConfig(new ParallelRunConfig(true, $taskManager));
+```
+
+### Worker
+
+Worker is a supervisor config which running the process which handles your tasks. 
+Make sure supervisor is installed on your machine. The example of supervisor config is located in worker/worker.conf.
+Please, configure the worker.php before running the supervisor config. 
+You have to put the same configuration of the client there as in your main application.
+Copy supervisor config to the specific folder which specified in etc/init.d/supervisord.conf. 
+And, please don't forget to adjust the path of worker.php aligned to your application base directory.
+
+```bash
+
+
+
 ## :white_check_mark: Testing
 Requires docker-compose and docker installed.
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "php": "^7.4 || ^8.0",
         "guzzlehttp/guzzle": "^6.5 || ^7.0",
         "ext-json": "*",
-        "art4/json-api-client": "^1.0"
+        "art4/json-api-client": "^1.0",
+        "predis/predis": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,17 @@ services:
       - "1021:80"
     volumes:
       - .:/app
+
+  redis:
+    image: redis:alpine
+    container_name: abr-php-redis
+    ports:
+      - "63846:6379"
+    volumes:
+      - redis:/data
+
+
+volumes:
+    redis:
+      driver: local
+

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,5 +12,8 @@
     <testsuite name="unit">
       <directory suffix="Test.php">tests/Unit/</directory>
     </testsuite>
+    <testsuite name="Integration">
+      <directory suffix="Test.php">tests/Integration/</directory>
+    </testsuite>
   </testsuites>
 </phpunit>

--- a/src/Builders/ConfigBuilder.php
+++ b/src/Builders/ConfigBuilder.php
@@ -1,24 +1,31 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Abrouter\Client\Builders;
 
 use Abrouter\Client\Config\Config;
+use Abrouter\Client\Config\ParallelRunConfig;
+use Abrouter\Client\Contracts\KvStorageContract;
 
 class ConfigBuilder
 {
     private const DEFAULT_HOST = 'https://abrouter.com';
-    
+
     /**
      * @var string $host
      */
     private string $host;
-    
+
     /**
      * @var string $token
      */
     private string $token;
-    
+
+    private ?ParallelRunConfig $parallelRunConfig = null;
+
+    private ?KvStorageContract $kvStorageContract = null;
+
     /**
      * @param string $host
      *
@@ -29,7 +36,7 @@ class ConfigBuilder
         $this->host = $host;
         return $this;
     }
-    
+
     /**
      * @param string $token
      *
@@ -40,12 +47,26 @@ class ConfigBuilder
         $this->token = $token;
         return $this;
     }
-    
+
+    public function setParallelRunConfig(ParallelRunConfig $parallelRunConfig): self
+    {
+        $this->parallelRunConfig = $parallelRunConfig;
+        return $this;
+    }
+
+    public function setKvStorage(KvStorageContract $kvStorageContract): self
+    {
+        $this->kvStorageContract = $kvStorageContract;
+        return $this;
+    }
+
     public function build(): Config
     {
         return new Config(
             $this->token,
-            $this->host ?? self::DEFAULT_HOST
+            $this->host ?? self::DEFAULT_HOST,
+            $this->parallelRunConfig,
+            $this->kvStorageContract
         );
     }
 }

--- a/src/Builders/Payload/ExperimentRunPayloadBuilder.php
+++ b/src/Builders/Payload/ExperimentRunPayloadBuilder.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Builders\Payload;
 

--- a/src/Builders/RequestBuilder.php
+++ b/src/Builders/RequestBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Abrouter\Client\Builders;
@@ -8,39 +9,46 @@ use Abrouter\Client\Entities\Client\Request;
 class RequestBuilder
 {
     public const METHOD_POST = 'post';
-    
+    public const METHOD_GET = 'get';
+
     private string $method;
-    
+
     private string $url;
-    
-    private array $jsonPayload;
+
+    private array $jsonPayload = [];
 
     private array $headers;
-    
+
     public function post(): self
     {
         $this->method = self::METHOD_POST;
         return $this;
     }
-    
+
+    public function get(): self
+    {
+        $this->method = self::METHOD_GET;
+        return $this;
+    }
+
     public function url(string $url): self
     {
         $this->url = $url;
         return $this;
     }
-    
+
     public function withJsonPayload(array $payload): self
     {
         $this->jsonPayload = $payload;
         return $this;
     }
-    
+
     public function withHeaders(array $headers): self
     {
         $this->headers = $headers;
         return $this;
     }
-    
+
     public function build(): Request
     {
         return new Request($this->method, $this->url, $this->jsonPayload, $this->headers);

--- a/src/Builders/UrlBuilder.php
+++ b/src/Builders/UrlBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Abrouter\Client\Builders;
@@ -10,28 +11,47 @@ class UrlBuilder
     public const RUN_EXPERIMENT_API_URL = 'api/v1/experiment/run';
     public const RUN_FEATURE_FLAG_API_URL = 'api/v1/feature-toggles/run';
     public const SEND_EVENT_API_URL = 'api/v1/event';
-    
+    public const FETCH_BRANCHES_API_URL = 'api/v1/experiments';
+    public const ADD_USER_TO_EXP = 'api/v1/experiments/add-user';
+    public const LIST_EXPERIMENT_USERS = 'api/v1/experiments/have-user/{id}';
+    public const LIST_USER_EVENTS = 'api/v1/statistics/user/{id}';
+
     /**
      * @var HostConfigAccessor
      */
     private HostConfigAccessor $hostConfigAccessor;
-    
-    private string $host;
-    
+
+
     private string $url;
-    
+
     public function __construct(HostConfigAccessor $hostConfigAccessor)
     {
         $this->hostConfigAccessor = $hostConfigAccessor;
         $this->host = $hostConfigAccessor->getHost();
     }
-    
-    public function runExperimentUri()
+
+    public function runExperimentUri(): self
     {
         return $this->setUrl(self::RUN_EXPERIMENT_API_URL);
     }
 
-    public function runFeatureFlagUri()
+    public function addUserToExp(): self
+    {
+        return $this->setUrl(self::ADD_USER_TO_EXP);
+    }
+
+    public function fetchBranchesUri(string $alias = null): self
+    {
+        //todo: make it in the right way
+        $filter = '';
+        if ($alias !== null) {
+            $filter = '?include=branches&filter[alias]=' . $alias;
+        }
+
+        return $this->setUrl(self::FETCH_BRANCHES_API_URL . $filter);
+    }
+
+    public function runFeatureFlagUri(): self
     {
         return $this->setUrl(self::RUN_FEATURE_FLAG_API_URL);
     }
@@ -40,24 +60,34 @@ class UrlBuilder
     {
         return $this->setUrl(self::SEND_EVENT_API_URL);
     }
-    
+
+    public function listExperimentUsersUri(string $id): self
+    {
+        return $this->setUrl(str_replace('{id}', $id, self::LIST_EXPERIMENT_USERS));
+    }
+
+    public function listUserEvents(string $id): self
+    {
+        return $this->setUrl(str_replace('{id}', $id, self::LIST_USER_EVENTS));
+    }
+
     public function build(): string
     {
         return $this->injectHost($this->url);
     }
-    
+
     private function reset()
     {
         $this->url = '';
         return $this;
     }
-    
+
     private function setUrl(string $url): self
     {
         $this->url = $url;
         return $this;
     }
-    
+
     private function injectHost(string $uri)
     {
         return join('/', [$this->hostConfigAccessor->getHost(), $uri]);

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client;
 
@@ -19,6 +20,8 @@ class Client
      */
     private StatisticsManager $statisticsManager;
 
+    private FeatureFlagManager $featureFlagManager;
+
     public function __construct(
         ExperimentManager $experimentManager,
         FeatureFlagManager $featureFlagManager,
@@ -28,7 +31,7 @@ class Client
         $this->featureFlagManager = $featureFlagManager;
         $this->statisticsManager = $statisticsManager;
     }
-    
+
     public function experiments(): ExperimentManager
     {
         return $this->experimentManager;

--- a/src/Collections/TasksCollection.php
+++ b/src/Collections/TasksCollection.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Collections;
+
+use Abrouter\Client\Contracts\TaskContract;
+use Abrouter\Client\Contracts\TasksCollectionContract;
+
+class TasksCollection implements TasksCollectionContract
+{
+    /**
+     * @var TaskContract[]
+     */
+    private array $tasks;
+
+    public function __construct(TaskContract ...$tasks)
+    {
+        $this->tasks = $tasks;
+    }
+
+    public function getAll(): array
+    {
+        return $this->tasks;
+    }
+}

--- a/src/Config/Accessors/BaseAccessor.php
+++ b/src/Config/Accessors/BaseAccessor.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Abrouter\Client\Config\Accessors;
+
+use Abrouter\Client\Config\Config;
+
+abstract class BaseAccessor
+{
+    /**
+     * @var Config
+     */
+    private $config;
+
+    final public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
+    final protected function getConfig(): Config
+    {
+        return $this->config;
+    }
+}

--- a/src/Config/Accessors/HostConfigAccessor.php
+++ b/src/Config/Accessors/HostConfigAccessor.php
@@ -1,24 +1,13 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Abrouter\Client\Config\Accessors;
 
-use Abrouter\Client\Config\Config;
-
-class HostConfigAccessor
+class HostConfigAccessor extends BaseAccessor
 {
-    /**
-     * @var Config
-     */
-    private Config $config;
-    
-    public function __construct(Config $config)
-    {
-        $this->config = $config;
-    }
-    
     public function getHost(): string
     {
-        return $this->config->getHost();
+        return $this->getConfig()->getHost();
     }
 }

--- a/src/Config/Accessors/KvStorageConfigAccessor.php
+++ b/src/Config/Accessors/KvStorageConfigAccessor.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Config\Accessors;
+
+use Abrouter\Client\Contracts\KvStorageContract;
+
+class KvStorageConfigAccessor extends BaseAccessor
+{
+    public function getKvStorage(): ?KvStorageContract
+    {
+        return $this->getConfig()->getKvStorage();
+    }
+
+    public function hasKvStorage(): bool
+    {
+        return $this->getConfig()->getKvStorage() !== null;
+    }
+}

--- a/src/Config/Accessors/ParallelRunConfigAccessor.php
+++ b/src/Config/Accessors/ParallelRunConfigAccessor.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Config\Accessors;
+
+use Abrouter\Client\Contracts\KvStorageContract;
+use Abrouter\Client\Contracts\TaskManagerContract;
+
+class ParallelRunConfigAccessor extends BaseAccessor
+{
+    public function isEnabled(): bool
+    {
+        if ($this->getConfig()->getParallelRunConfig() === null) {
+            return false;
+        }
+
+        return $this->getConfig()->getParallelRunConfig()->isEnabled();
+    }
+
+    public function getKvStorage(): ?KvStorageContract
+    {
+        return $this->getConfig()->getKvStorage();
+    }
+
+    public function getTaskManager(): ?TaskManagerContract
+    {
+        if ($this->getConfig()->getParallelRunConfig() === null) {
+            return null;
+        }
+
+        return $this->getConfig()->getParallelRunConfig()->getTaskManager();
+    }
+}

--- a/src/Config/Accessors/RedisConfigAccessor.php
+++ b/src/Config/Accessors/RedisConfigAccessor.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Config\Accessors;
+
+use Abrouter\Client\Config\RedisConfig;
+
+class RedisConfigAccessor extends BaseAccessor
+{
+    public function getRedisConfig(): ?RedisConfig
+    {
+        return $this->getConfig()->getRedisConfig();
+    }
+}

--- a/src/Config/Accessors/TokenConfigAccessor.php
+++ b/src/Config/Accessors/TokenConfigAccessor.php
@@ -1,24 +1,13 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Abrouter\Client\Config\Accessors;
 
-use Abrouter\Client\Config\Config;
-
-class TokenConfigAccessor
+class TokenConfigAccessor extends BaseAccessor
 {
-    /**
-     * @var Config
-     */
-    private Config $config;
-    
-    public function __construct(Config $config)
-    {
-        $this->config = $config;
-    }
-    
     public function getToken(): string
     {
-        return $this->config->getToken();
+        return $this->getConfig()->getToken();
     }
 }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -1,7 +1,10 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Abrouter\Client\Config;
+
+use Abrouter\Client\Contracts\KvStorageContract;
 
 class Config
 {
@@ -14,13 +17,27 @@ class Config
      * @var string $host
      */
     private string $host;
-    
-    public function __construct(string $token, string $host)
-    {
+
+    /**
+     * @var ParallelRunConfig|null
+     */
+    private ?ParallelRunConfig $parallelRunConfig = null;
+
+    /**
+     * @var KvStorageContract|null
+     */
+    private ?KvStorageContract $kvStorageConfig = null;
+
+    private ?RedisConfig $redisConfig = null;
+
+    public function __construct(
+        string $token,
+        string $host
+    ) {
         $this->token = $token;
         $this->host = $host;
     }
-    
+
     /**
      * @return string
      */
@@ -28,12 +45,54 @@ class Config
     {
         return $this->host;
     }
-    
+
     /**
      * @return string
      */
     public function getToken(): string
     {
         return $this->token;
+    }
+
+    /**
+     * @return KvStorageContract|null
+     */
+    public function getKvStorage(): ?KvStorageContract
+    {
+        return $this->kvStorageConfig;
+    }
+
+    /**
+     * @return ParallelRunConfig|null
+     */
+    public function getParallelRunConfig(): ?ParallelRunConfig
+    {
+        return $this->parallelRunConfig;
+    }
+
+    public function setParallelRunConfig(ParallelRunConfig $parallelRunConfig): self
+    {
+        $this->parallelRunConfig = $parallelRunConfig;
+        return $this;
+    }
+
+    public function setKvStorageConfig(KvStorageContract $parallelRunConfig): self
+    {
+        $this->kvStorageConfig = $parallelRunConfig;
+        return $this;
+    }
+
+    public function setRedisConfig(RedisConfig $redisConfig): self
+    {
+        $this->redisConfig = $redisConfig;
+        return $this;
+    }
+
+    /**
+     * @return RedisConfig
+     */
+    public function getRedisConfig(): ?RedisConfig
+    {
+        return $this->redisConfig;
     }
 }

--- a/src/Config/KvStorageConfig.php
+++ b/src/Config/KvStorageConfig.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Config;
+
+class KvStorageConfig
+{
+    /**
+     * @var string
+     */
+    private string $kvStorageHost;
+
+    /**
+     * @var int
+     */
+    private $kvStoragePort;
+
+    /**
+     * @var string
+     */
+    private $kvStoragePassword;
+
+    /**
+     * @var string
+     */
+    private $kvStorageDatabase;
+
+    public function __construct(
+        string $kvStorageHost,
+        int $kvStoragePort,
+        string $kvStoragePassword,
+        string $kvStorageDatabase
+    ) {
+        $this->kvStorageHost = $kvStorageHost;
+        $this->kvStoragePort = $kvStoragePort;
+        $this->kvStoragePassword = $kvStoragePassword;
+        $this->kvStorageDatabase = $kvStorageDatabase;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKvStorageHost(): string
+    {
+        return $this->kvStorageHost;
+    }
+
+    /**
+     * @return int
+     */
+    public function getKvStoragePort(): int
+    {
+        return $this->kvStoragePort;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKvStoragePassword(): string
+    {
+        return $this->kvStoragePassword;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKvStorageDatabase(): string
+    {
+        return $this->kvStorageDatabase;
+    }
+}

--- a/src/Config/ParallelRunConfig.php
+++ b/src/Config/ParallelRunConfig.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Config;
+
+use Abrouter\Client\Contracts\TaskManagerContract;
+
+class ParallelRunConfig
+{
+    /**
+     * @var bool
+     */
+    private $enabled;
+
+    private ?TaskManagerContract $taskManager;
+
+    public function __construct(bool $enabled, TaskManagerContract $taskManager = null)
+    {
+        $this->enabled = $enabled;
+        $this->taskManager = $taskManager;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @return TaskManagerContract|null
+     */
+    public function getTaskManager(): ?TaskManagerContract
+    {
+        return $this->taskManager;
+    }
+}

--- a/src/Config/RedisConfig.php
+++ b/src/Config/RedisConfig.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Config;
+
+/**
+ * Using Redis
+ */
+class RedisConfig
+{
+    private string $redisHost;
+
+    private int $port;
+
+    private string $username;
+
+    private string $db;
+
+    private string $password;
+
+    public function __construct(string $redisHost, int $port, string $username, string $db, string $password)
+    {
+        $this->redisHost = $redisHost;
+        $this->port = $port;
+        $this->username = $username;
+        $this->db = $db;
+        $this->password = $password;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRedisHost(): string
+    {
+        return $this->redisHost;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPort(): int
+    {
+        return $this->port;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDb(): string
+    {
+        return $this->db;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+}

--- a/src/Contracts/KvStorageContract.php
+++ b/src/Contracts/KvStorageContract.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Contracts;
+
+interface KvStorageContract
+{
+    public function put(string $key, string $value, int $expiresInSeconds = 0): void;
+    public function remove(string $key): void;
+    public function get(string $key);
+}

--- a/src/Contracts/TaskContract.php
+++ b/src/Contracts/TaskContract.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Contracts;
+
+interface TaskContract
+{
+}

--- a/src/Contracts/TaskManagerContract.php
+++ b/src/Contracts/TaskManagerContract.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Contracts;
+
+interface TaskManagerContract
+{
+    public function queue(TaskContract $task): void;
+    public function work(int $iterationsLimit = 0): void;
+}

--- a/src/Contracts/TasksCollectionContract.php
+++ b/src/Contracts/TasksCollectionContract.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Contracts;
+
+interface TasksCollectionContract
+{
+    public function __construct(TaskContract ...$tasks);
+
+    /**
+     * @return TaskContract[]
+     */
+    public function getAll(): array;
+}

--- a/src/DB/RedisConnection.php
+++ b/src/DB/RedisConnection.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\DB;
+
+use Abrouter\Client\Config\Accessors\RedisConfigAccessor;
+use Abrouter\Client\Config\RedisConfig;
+use Predis\Client;
+
+class RedisConnection
+{
+    private static ?Client $connection;
+
+    private ?RedisConfig $redisConfig;
+
+    public function __construct(RedisConfigAccessor $redisConfigAccessor)
+    {
+        $this->redisConfig = $redisConfigAccessor->getRedisConfig();
+    }
+
+    public function getConnection()
+    {
+        if (isset(self::$connection)) {
+            return self::$connection;
+        }
+
+        self::$connection = new Client([
+            'scheme' => 'tcp',
+            'host'   => $this->redisConfig->getRedisHost(),
+            'port'   => $this->redisConfig->getPort(),
+            'database' => $this->redisConfig->getDb(),
+            'username' => $this->redisConfig->getUsername(),
+            'password' => $this->redisConfig->getPassword(),
+        ]);
+
+        return self::$connection;
+    }
+}

--- a/src/DTO/EventDTO.php
+++ b/src/DTO/EventDTO.php
@@ -59,14 +59,14 @@ class EventDTO
      * @param string|null $created_at
      */
     public function __construct(
-        ?string $temporaryUserId,
-        ?string $userId,
+        ?string $temporaryUserId = null,
+        ?string $userId = null,
         string $event,
-        ?string $tag,
-        ?string $referrer,
-        ?array $meta,
-        ?string $ip,
-        ?string $created_at
+        ?string $tag = null,
+        ?string $referrer = null,
+        ?array $meta = null,
+        ?string $ip = null,
+        ?string $created_at = null
     ) {
         $this->temporaryUserId = $temporaryUserId;
         $this->userId = $userId;

--- a/src/Entities/Client/Request.php
+++ b/src/Entities/Client/Request.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Abrouter\Client\Entities\Client;
@@ -9,22 +10,22 @@ class Request implements RequestInterface
      * @var string
      */
     private string $method;
-    
+
     /**
      * @var array
      */
     private array $payload;
-    
+
     /**
      * @var array
      */
     private array $headers;
-    
+
     /**
      * @var string
      */
     private string $url;
-    
+
     public function __construct(
         string $method,
         string $url,
@@ -36,7 +37,7 @@ class Request implements RequestInterface
         $this->payload = $payload;
         $this->headers = $headers;
     }
-    
+
     /**
      * @return string
      */
@@ -44,7 +45,7 @@ class Request implements RequestInterface
     {
         return $this->method;
     }
-    
+
     /**
      * @return array
      */
@@ -52,12 +53,12 @@ class Request implements RequestInterface
     {
         return $this->payload;
     }
-    
+
     public function getHeaders(): array
     {
         return $this->headers;
     }
-    
+
     /**
      * @return string
      */

--- a/src/Entities/Client/RequestInterface.php
+++ b/src/Entities/Client/RequestInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Abrouter\Client\Entities\Client;
@@ -6,10 +7,10 @@ namespace Abrouter\Client\Entities\Client;
 interface RequestInterface
 {
     public function getMethod(): string;
-    
+
     public function getUrl(): string;
-    
+
     public function getPayload(): array;
-    
+
     public function getHeaders(): array;
 }

--- a/src/Entities/Client/Response.php
+++ b/src/Entities/Client/Response.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Abrouter\Client\Entities\Client;
@@ -9,12 +10,12 @@ class Response implements ResponseInterface
      * @var array
      */
     private array $responseJson;
-    
+
     public function __construct(array $responseJson)
     {
         $this->responseJson = $responseJson;
     }
-    
+
     public function getResponseJson(): array
     {
         return $this->responseJson;

--- a/src/Entities/Client/ResponseInterface.php
+++ b/src/Entities/Client/ResponseInterface.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Entities\Client;
 

--- a/src/Entities/JsonPayload.php
+++ b/src/Entities/JsonPayload.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types =1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Entities;
 
@@ -9,12 +10,12 @@ class JsonPayload
      * @var array
      */
     private array $payload;
-    
+
     public function __construct(array $payload)
     {
         $this->payload = $payload;
     }
-    
+
     /**
      * @return array
      */

--- a/src/Entities/SentEvent.php
+++ b/src/Entities/SentEvent.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Entities;
 
@@ -9,7 +10,7 @@ class SentEvent
      * @var string
      */
     private $event;
-    
+
     /**
      * @param string|null $ip
      */
@@ -18,7 +19,7 @@ class SentEvent
     ) {
         $this->event = $event;
     }
-    
+
     /**
      * @return bool
      */

--- a/src/Events/EventDispatcher.php
+++ b/src/Events/EventDispatcher.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Events;
+
+use Abrouter\Client\Contracts\TaskContract;
+use Abrouter\Client\Services\TaskManager\TaskStorage;
+
+class EventDispatcher
+{
+    private EventHandlersMap $eventHandlersMap;
+
+    private TaskStorage $taskStorage;
+
+    public function __construct(EventHandlersMap $eventHandlersMap, TaskStorage $taskStorage)
+    {
+        $this->eventHandlersMap = $eventHandlersMap;
+        $this->taskStorage = $taskStorage;
+    }
+
+    public function dispatch(TaskContract $taskContract, bool $async = false): void
+    {
+        if ($async) {
+            $this->taskStorage->publish($taskContract);
+            return ;
+        }
+
+        $handlers = $this->eventHandlersMap->getTaskHandlers($taskContract);
+        if ($handlers === null) {
+            return ;
+        }
+
+        foreach ($handlers as $handler) {
+            $handler->handle($taskContract);
+        }
+    }
+}

--- a/src/Events/EventHandlersMap.php
+++ b/src/Events/EventHandlersMap.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Events;
+
+use Abrouter\Client\Contracts\TaskContract;
+use Abrouter\Client\Events\Handlers\AddUserToBranchHandler;
+use Abrouter\Client\Events\Handlers\StatisticsSenderHandler;
+use Abrouter\Client\Services\ExperimentsParallelRun\AddUserToBranchTask;
+use Abrouter\Client\Services\Statistics\SendEventTask;
+
+class EventHandlersMap
+{
+    private AddUserToBranchHandler $addUserToBranchHandler;
+
+    private StatisticsSenderHandler $statisticsSenderHandler;
+
+    private array $map;
+
+    public function __construct(
+        AddUserToBranchHandler $addUserToBranchHandler,
+        StatisticsSenderHandler $statisticsSenderHandler
+    ) {
+        $this->addUserToBranchHandler = $addUserToBranchHandler;
+        $this->statisticsSenderHandler = $statisticsSenderHandler;
+        $this->map = $this->getInitialMap();
+    }
+
+    /**
+     * @param TaskContract $taskContract
+     * @return HandlerInterface[]
+     */
+    public function getTaskHandlers(TaskContract $taskContract): ?array
+    {
+        $task = get_class($taskContract);
+        if (empty($this->getMap()[$task])) {
+            return null;
+        }
+
+        return $this->getMap()[$task];
+    }
+
+    /**
+     * @return array
+     */
+    public function getMap(): array
+    {
+        return $this->map;
+    }
+
+    public function replaceHandlers(string $task, array $handlers): self
+    {
+        $this->map[$task] = $handlers;
+        return $this;
+    }
+
+    public function appendHandler(string $task, HandlerInterface $handler): self
+    {
+        $this->map[$task][] = $handler;
+        return $this;
+    }
+
+    private function getInitialMap(): array
+    {
+        return [
+            AddUserToBranchTask::class => [
+                $this->addUserToBranchHandler,
+            ],
+            SendEventTask::class => [
+                $this->statisticsSenderHandler,
+            ],
+        ];
+    }
+}

--- a/src/Events/HandlerInterface.php
+++ b/src/Events/HandlerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Events;
+
+use Abrouter\Client\Contracts\TaskContract;
+
+interface HandlerInterface
+{
+    public function handle(TaskContract $taskContract): bool;
+}

--- a/src/Events/Handlers/AddUserToBranchHandler.php
+++ b/src/Events/Handlers/AddUserToBranchHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Events\Handlers;
+
+use Abrouter\Client\Contracts\TaskContract;
+use Abrouter\Client\Events\HandlerInterface;
+use Abrouter\Client\RemoteEntity\Managers\UserBranchManager;
+use Abrouter\Client\Services\ExperimentsParallelRun\AddUserToBranchTask;
+
+class AddUserToBranchHandler implements HandlerInterface
+{
+    private UserBranchManager $userBranchManager;
+
+    public function __construct(UserBranchManager $userBranchManager)
+    {
+        $this->userBranchManager = $userBranchManager;
+    }
+
+    public function handle(TaskContract $taskContract): bool
+    {
+        if (!($taskContract instanceof AddUserToBranchTask)) {
+            return false;
+        }
+
+        $this->userBranchManager->addUserToBranch(
+            $taskContract->getExperimentId(),
+            $taskContract->getExperimentAlias(),
+            $taskContract->getBranch(),
+            $taskContract->getUserSignature(),
+        );
+
+        return true;
+    }
+}

--- a/src/Events/Handlers/StatisticsSenderHandler.php
+++ b/src/Events/Handlers/StatisticsSenderHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Events\Handlers;
+
+use Abrouter\Client\Contracts\TaskContract;
+use Abrouter\Client\Events\HandlerInterface;
+use Abrouter\Client\Exceptions\InvalidJsonApiResponseException;
+use Abrouter\Client\Exceptions\SendEventRequestException;
+use Abrouter\Client\Services\Statistics\SendEventService;
+use Abrouter\Client\Services\Statistics\SendEventTask;
+
+class StatisticsSenderHandler implements HandlerInterface
+{
+    private SendEventService $sendEventService;
+
+    public function __construct(SendEventService $sendEventService)
+    {
+        $this->sendEventService = $sendEventService;
+    }
+
+    /**
+     * @param TaskContract $taskContract
+     * @return bool
+     * @throws InvalidJsonApiResponseException
+     * @throws SendEventRequestException
+     */
+    public function handle(TaskContract $taskContract): bool
+    {
+        if (!($taskContract instanceof SendEventTask)) {
+            return false;
+        }
+
+        return $this->sendEventService->sendEvent(
+            $taskContract->getEventDTO()
+        )->isSuccessful();
+    }
+}

--- a/src/Exceptions/InvalidJsonApiResponseException.php
+++ b/src/Exceptions/InvalidJsonApiResponseException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Abrouter\Client\Exceptions;

--- a/src/Exceptions/RunExperimentRequestException.php
+++ b/src/Exceptions/RunExperimentRequestException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Abrouter\Client\Exceptions;

--- a/src/Exceptions/SendEventRequestException.php
+++ b/src/Exceptions/SendEventRequestException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Abrouter\Client\Exceptions;

--- a/src/Http/RequestExecutor.php
+++ b/src/Http/RequestExecutor.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Abrouter\Client\Http;
@@ -16,12 +17,12 @@ class RequestExecutor
      * @var Client
      */
     private Client $client;
-    
+
     public function __construct(Client $client)
     {
         $this->client = $client;
     }
-    
+
     /**
      * @param RequestInterface $request
      *
@@ -34,9 +35,9 @@ class RequestExecutor
             RequestOptions::HEADERS => $request->getHeaders(),
             RequestOptions::JSON => $request->getPayload(),
         ]);
-        
+
         $jsonResponse = json_decode($request->getBody()->getContents(), true);
-        
+
         return new Response($jsonResponse);
     }
 }

--- a/src/Manager/ExperimentManager.php
+++ b/src/Manager/ExperimentManager.php
@@ -1,13 +1,16 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Manager;
 
 use Abrouter\Client\Builders\Payload\ExperimentRunPayloadBuilder;
-use Abrouter\Client\Entities\RunExperiment;
+use Abrouter\Client\RemoteEntity\Entities\ExperimentRanResult;
 use Abrouter\Client\Exceptions\InvalidJsonApiResponseException;
 use Abrouter\Client\Exceptions\RunExperimentRequestException;
 use Abrouter\Client\Requests\RunExperimentRequest;
+use Abrouter\Client\Services\ExperimentsParallelRun\ParallelRunner;
+use Abrouter\Client\Services\ExperimentsParallelRun\ParallelRunSwitch;
 use Abrouter\Client\Transformers\RunExperimentRequestTransformer;
 
 class ExperimentManager
@@ -16,41 +19,61 @@ class ExperimentManager
      * @var RunExperimentRequest
      */
     private RunExperimentRequest $runExperimentRequest;
-    
+
     /**
      * @var ExperimentRunPayloadBuilder
      */
     private ExperimentRunPayloadBuilder $experimentRunPayloadBuilder;
-    
+
     /**
      * @var RunExperimentRequestTransformer
      */
     private RunExperimentRequestTransformer $experimentRequestTransformer;
-    
+
+    private ParallelRunSwitch $parallelRunSwitch;
+
+    private ParallelRunner $parallelRunner;
+
     public function __construct(
         RunExperimentRequest $runExperimentRequest,
         ExperimentRunPayloadBuilder $experimentRunPayloadBuilder,
-        RunExperimentRequestTransformer $experimentRequestTransformer
+        RunExperimentRequestTransformer $experimentRequestTransformer,
+        ParallelRunSwitch $parallelRunSwitch,
+        ParallelRunner $parallelRunner
     ) {
         $this->runExperimentRequest = $runExperimentRequest;
         $this->experimentRunPayloadBuilder = $experimentRunPayloadBuilder;
         $this->experimentRequestTransformer = $experimentRequestTransformer;
+        $this->parallelRunSwitch = $parallelRunSwitch;
+        $this->parallelRunner = $parallelRunner;
     }
-    
+
     /**
      * @param string $userSignature
      * @param string $experimentUid
      *
-     * @return RunExperiment
-     * @throws InvalidJsonApiResponseException
-     * @throws RunExperimentRequestException
+     * @return ExperimentRanResult
      */
-    public function run(string $userSignature, string $experimentUid): RunExperiment
+    public function run(string $userSignature, string $experimentUid): ExperimentRanResult
+    {
+        if ($this->parallelRunSwitch->isEnabled()) {
+            return $this->runInParallel($userSignature, $experimentUid);
+        }
+
+        return $this->runSync($userSignature, $experimentUid);
+    }
+
+    private function runSync(string $userSignature, string $experimentUid): ExperimentRanResult
     {
         $payload = $this->experimentRunPayloadBuilder->build($userSignature, $experimentUid);
         $response = $this->runExperimentRequest->runExperiment($payload);
         $runExperiment = $this->experimentRequestTransformer->transform($response);
-        
+
         return $runExperiment;
+    }
+
+    private function runInParallel(string $userSignature, string $experimentAlias): ExperimentRanResult
+    {
+        return $this->parallelRunner->run($userSignature, $experimentAlias);
     }
 }

--- a/src/Manager/FeatureFlagManager.php
+++ b/src/Manager/FeatureFlagManager.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Abrouter\Client\Manager;
 
 use Abrouter\Client\Builders\Payload\FeatureFlagRunPayloadBuilder;
+use Abrouter\Client\Exceptions\InvalidJsonApiResponseException;
+use Abrouter\Client\Exceptions\RunFeatureFlagRequestException;
+use Abrouter\Client\RemoteEntity\Cache\Cacher;
+use Abrouter\Client\RemoteEntity\Entities\FeatureFlagRan;
 use Abrouter\Client\Requests\RunFeatureFlagRequest;
 use Abrouter\Client\Transformers\RunFeatureFlagRequestTransformer;
 
@@ -25,27 +29,58 @@ class FeatureFlagManager
      */
     private RunFeatureFlagRequestTransformer $runFeatureFlagRequestTransformer;
 
+    /**
+     * @var Cacher
+     */
+    private Cacher $cacher;
+
+    /**
+     * @param RunFeatureFlagRequest $runFeatureFlagRequest
+     * @param FeatureFlagRunPayloadBuilder $featureFlagRunPayloadBuilder
+     * @param RunFeatureFlagRequestTransformer $runFeatureFlagRequestTransformer
+     * @param Cacher $cacher
+     */
     public function __construct(
         RunFeatureFlagRequest $runFeatureFlagRequest,
         FeatureFlagRunPayloadBuilder $featureFlagRunPayloadBuilder,
-        RunFeatureFlagRequestTransformer $runFeatureFlagRequestTransformer
+        RunFeatureFlagRequestTransformer $runFeatureFlagRequestTransformer,
+        Cacher $cacher
     ) {
         $this->runFeatureFlagRequest = $runFeatureFlagRequest;
         $this->featureFlagRunPayloadBuilder = $featureFlagRunPayloadBuilder;
         $this->runFeatureFlagRequestTransformer = $runFeatureFlagRequestTransformer;
+        $this->cacher = $cacher;
     }
 
     /**
      * @param string $id
      * @return bool
+     * @throws InvalidJsonApiResponseException
+     * @throws RunFeatureFlagRequestException
      */
-
     public function run(string $id): bool
     {
-        $payload = $this->featureFlagRunPayloadBuilder->build($id);
-        $response = $this->runFeatureFlagRequest->runFeatureFlag($payload);
-        $runFeatureFlag = $this->runFeatureFlagRequestTransformer->transform($response);
+        $featureFlagRun = function () use ($id) {
+            $payload = $this->featureFlagRunPayloadBuilder->build($id);
+            $response = $this->runFeatureFlagRequest->runFeatureFlag($payload);
+            $runFeatureFlag = $this->runFeatureFlagRequestTransformer->transform($response);
 
-        return $runFeatureFlag;
+            return new FeatureFlagRan($runFeatureFlag);
+        };
+
+        if ($this->cacher !== null && $this->cacher->isEnabled()) {
+            /**
+             * @var FeatureFlagRan $object
+             */
+             $object = $this->cacher->fetch(
+                 $id,
+                 'feature-flag',
+                 300,
+                 $featureFlagRun
+             );
+             return $object->isEnabled();
+        }
+
+        return $featureFlagRun()->isEnabled();
     }
 }

--- a/src/Manager/StatisticsManager.php
+++ b/src/Manager/StatisticsManager.php
@@ -1,38 +1,35 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Manager;
 
-use Abrouter\Client\Builders\Payload\EventSendPayloadBuilder;
-use Abrouter\Client\Entities\SentEvent;
-use Abrouter\Client\Exceptions\InvalidJsonApiResponseException;
-use Abrouter\Client\Exceptions\SendEventRequestException;
-use Abrouter\Client\Requests\SendEventRequest;
-use Abrouter\Client\Transformers\SendEventRequestTransformer;
+use Abrouter\Client\Events\EventDispatcher;
 use Abrouter\Client\DTO\EventDTO;
+use Abrouter\Client\Services\ExperimentsParallelRun\ParallelRunSwitch;
+use Abrouter\Client\Services\Statistics\SendEventTask;
 
 class StatisticsManager
 {
-    public function __construct(
-        SendEventRequest $sendEventRequest,
-        EventSendPayloadBuilder $eventSendPayloadBuilder,
-        SendEventRequestTransformer $sendEventRequestTransformer
-    ) {
-        $this->sendEventRequest = $sendEventRequest;
-        $this->eventSendPayloadBuilder = $eventSendPayloadBuilder;
-        $this->sendEventRequestTransformer = $sendEventRequestTransformer;
-    }
+    private EventDispatcher $eventDispatcher;
+
+    private ParallelRunSwitch $parallelRunSwitch;
+
     /**
-     * @param EventDTO
-     *
-     * @return SentEvent
+     * @param EventDispatcher $eventDispatcher
+     * @param ParallelRunSwitch $parallelRunSwitch
      */
-    public function sendEvent(EventDTO $eventDTO): SentEvent
+    public function __construct(EventDispatcher $eventDispatcher, ParallelRunSwitch $parallelRunSwitch)
     {
-        $payload = $this->eventSendPayloadBuilder->build($eventDTO);
-        $response = $this->sendEventRequest->sendEvent($payload);
-        $sentEvent = $this->sendEventRequestTransformer->transform($response);
-        
-        return $sentEvent;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->parallelRunSwitch = $parallelRunSwitch;
+    }
+
+    public function sendEvent(EventDTO $eventDTO): void
+    {
+        $this->eventDispatcher->dispatch(
+            new SendEventTask($eventDTO),
+            $this->parallelRunSwitch->isEnabled()
+        );
     }
 }

--- a/src/RemoteEntity/Cache/Cacher.php
+++ b/src/RemoteEntity/Cache/Cacher.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\RemoteEntity\Cache;
+
+use Abrouter\Client\Contracts\KvStorageContract;
+use Abrouter\Client\Config\Accessors\KvStorageConfigAccessor;
+
+class Cacher
+{
+    /**
+     * @var KvStorageContract|null
+     */
+    private ?KvStorageContract $kvStorageContract;
+
+    private bool $isEnabled;
+
+    public function __construct(KvStorageConfigAccessor $kvStorageConfigAccessor)
+    {
+        $this->kvStorageContract = $kvStorageConfigAccessor->getKvStorage();
+        $this->isEnabled = $kvStorageConfigAccessor->hasKvStorage();
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->isEnabled;
+    }
+
+    public function fetch(string $id, string $type, int $expireIn, callable $fetchFunction): ?object
+    {
+        $objectId = $this->getObjectId($id, $type);
+        $object = $this->kvStorageContract->get($objectId);
+        if ($object !== null) {
+            return unserialize($object);
+        }
+
+        $object = $fetchFunction();
+        $this->kvStorageContract->put($objectId, serialize($object), $expireIn);
+        return $object;
+    }
+
+    private function getObjectId(string $id, string $type): string
+    {
+        return join('', [
+           $type,
+           '-',
+           $id
+        ]);
+    }
+}

--- a/src/RemoteEntity/Collections/ExperimentBranchesCollection.php
+++ b/src/RemoteEntity/Collections/ExperimentBranchesCollection.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\RemoteEntity\Collections;
+
+use Abrouter\Client\RemoteEntity\Entities\ExperimentBranch;
+
+class ExperimentBranchesCollection
+{
+    /**
+     * @var ExperimentBranch[]
+     */
+    private array $experimentBranches;
+
+    /**
+     * @var string
+     */
+    private ?string $experimentId;
+
+    public function __construct(string $experimentId = null, ExperimentBranch ...$branches)
+    {
+        $this->experimentBranches = $branches;
+        $this->experimentId = $experimentId;
+    }
+
+    /**
+     * @return ExperimentBranch[]
+     */
+    public function getExperimentBranches(): array
+    {
+        return $this->experimentBranches;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExperimentId(): ?string
+    {
+        return $this->experimentId;
+    }
+}

--- a/src/RemoteEntity/Collections/ExperimentUserBranchesCollection.php
+++ b/src/RemoteEntity/Collections/ExperimentUserBranchesCollection.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\RemoteEntity\Collections;
+
+use Abrouter\Client\RemoteEntity\Entities\ExperimentUserBranch;
+
+class ExperimentUserBranchesCollection
+{
+    /**
+     * @var ExperimentUserBranch[]
+     */
+    private array $experimentUserBranches;
+
+    public function __construct(ExperimentUserBranch ...$branches)
+    {
+        $this->experimentUserBranches = $branches;
+    }
+
+    /**
+     * @return ExperimentUserBranch[]
+     */
+    public function getAll(): array
+    {
+        return $this->experimentUserBranches;
+    }
+}

--- a/src/RemoteEntity/Entities/ExperimentBranch.php
+++ b/src/RemoteEntity/Entities/ExperimentBranch.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\RemoteEntity\Entities;
+
+class ExperimentBranch
+{
+    /**
+     * @var string
+     */
+    private $uid;
+
+    /**
+     * @var int
+     */
+    private $percentage;
+
+    /**
+     * @var string
+     */
+    private $experimentId;
+
+    private string $id;
+
+    private string $experimentAlias;
+
+    public function __construct(string $id, string $uid, int $percentage, string $experimentAlias, string $experimentId)
+    {
+        $this->id = $id;
+        $this->uid = $uid;
+        $this->percentage = $percentage;
+        $this->experimentId = $experimentId;
+        $this->experimentAlias = $experimentAlias;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUid(): string
+    {
+        return $this->uid;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPercentage(): int
+    {
+        return $this->percentage;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExperimentId(): string
+    {
+        return $this->experimentId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/RemoteEntity/Entities/ExperimentRanResult.php
+++ b/src/RemoteEntity/Entities/ExperimentRanResult.php
@@ -1,26 +1,27 @@
 <?php
-declare(strict_types = 1);
 
-namespace Abrouter\Client\Entities;
+declare(strict_types=1);
 
-class RunExperiment
+namespace Abrouter\Client\RemoteEntity\Entities;
+
+class ExperimentRanResult
 {
     /**
      * @var string
      */
     private string $branchId;
-    
+
     /**
      * @var string
      */
     private string $experimentId;
-    
+
     public function __construct(string $branchId, string $experimentId)
     {
         $this->branchId = $branchId;
         $this->experimentId = $experimentId;
     }
-    
+
     /**
      * @return string
      */
@@ -28,7 +29,7 @@ class RunExperiment
     {
         return $this->branchId;
     }
-    
+
     /**
      * @return string
      */

--- a/src/RemoteEntity/Entities/ExperimentUserBranch.php
+++ b/src/RemoteEntity/Entities/ExperimentUserBranch.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\RemoteEntity\Entities;
+
+class ExperimentUserBranch
+{
+    /**
+     * @var string
+     */
+    private string $branchUid;
+
+    private string $experimentUid;
+
+    public function __construct(string $branchUid, $experimentUid)
+    {
+        $this->branchUid = $branchUid;
+        $this->experimentUid = $experimentUid;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBranchUid(): string
+    {
+        return $this->branchUid;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExperimentUid(): string
+    {
+        return $this->experimentUid;
+    }
+}

--- a/src/RemoteEntity/Entities/FeatureFlagRan.php
+++ b/src/RemoteEntity/Entities/FeatureFlagRan.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\RemoteEntity\Entities;
+
+class FeatureFlagRan
+{
+    private bool $isEnabled;
+
+    public function __construct(bool $isEnabled)
+    {
+        $this->isEnabled = $isEnabled;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled(): bool
+    {
+        return $this->isEnabled;
+    }
+}

--- a/src/RemoteEntity/Managers/UserBranchManager.php
+++ b/src/RemoteEntity/Managers/UserBranchManager.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\RemoteEntity\Managers;
+
+use Abrouter\Client\Builders\RequestBuilder;
+use Abrouter\Client\Builders\UrlBuilder;
+use Abrouter\Client\Config\Accessors\TokenConfigAccessor;
+use Abrouter\Client\Http\RequestExecutor;
+use Abrouter\Client\RemoteEntity\Repositories\Cached\ExperimentBranchesCacheRepository;
+
+class UserBranchManager
+{
+    /**
+     * @var UrlBuilder $urlBuilder
+     */
+    private UrlBuilder $urlBuilder;
+
+    /**
+     * @var RequestBuilder
+     */
+    private RequestBuilder $requestBuilder;
+
+    /**
+     * @var TokenConfigAccessor
+     */
+    private TokenConfigAccessor $tokenConfigAccessor;
+
+    /**
+     * @var RequestExecutor
+     */
+    private RequestExecutor $requestExecutor;
+
+    /**
+     * @var ExperimentBranchesCacheRepository
+     */
+    private ExperimentBranchesCacheRepository $experimentBranchesCacheRepository;
+
+    public function __construct(
+        UrlBuilder $urlBuilder,
+        RequestBuilder $requestBuilder,
+        TokenConfigAccessor $tokenConfigAccessor,
+        RequestExecutor $requestExecutor,
+        ExperimentBranchesCacheRepository $experimentBranchesCacheRepository
+    ) {
+        $this->urlBuilder = $urlBuilder;
+        $this->requestBuilder = $requestBuilder;
+        $this->tokenConfigAccessor = $tokenConfigAccessor;
+        $this->requestExecutor = $requestExecutor;
+        $this->experimentBranchesCacheRepository = $experimentBranchesCacheRepository;
+    }
+
+    public function addUserToBranch(
+        string $experimentId,
+        string $experimentAlias,
+        string $branchUid,
+        string $userSignature
+    ): void {
+        $branchId = $this->experimentBranchesCacheRepository->getBranchIdByUid($experimentAlias, $branchUid);
+
+        $request = $this->requestBuilder
+            ->post()
+            ->url($this->urlBuilder->addUserToExp()->build())
+            ->withHeaders([
+                'Authorization' => $this->tokenConfigAccessor->getToken()
+            ])
+            ->withJsonPayload([
+                'data' => [
+                    'type' => 'experiment_users',
+                    'attributes' => [
+                        'user_signature' => $userSignature,
+                    ],
+                    'relationships' => [
+                        'experiments' => [
+                            'data' => [
+                                'id' => $experimentId,
+                                'type' => 'experiments',
+                            ],
+                        ],
+                        'branches' => [
+                            'data' => [
+                                'id' => $branchId,
+                                'type' => 'experiment_branches',
+                            ]
+                        ]
+                    ],
+                ],
+            ])
+            ->build();
+
+        $this->requestExecutor->execute($request);
+    }
+}

--- a/src/RemoteEntity/Repositories/Cached/ExperimentBranchesCacheRepository.php
+++ b/src/RemoteEntity/Repositories/Cached/ExperimentBranchesCacheRepository.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\RemoteEntity\Repositories\Cached;
+
+use Abrouter\Client\RemoteEntity\Cache\Cacher;
+use Abrouter\Client\RemoteEntity\Collections\ExperimentBranchesCollection;
+use Abrouter\Client\RemoteEntity\Repositories\ExperimentBranchesRepository;
+
+class ExperimentBranchesCacheRepository
+{
+    private const ENTITY_TYPE_EXPERIMENT_BRANCHES = 'experiment-branches';
+    private const EXPIRES_IN_EXPERIMENT_BRANCHES = 3600 * 24;
+
+    /**
+     * @var ExperimentBranchesRepository
+     */
+    private $experimentBranchesRepository;
+
+    /**
+     * @var Cacher
+     */
+    private $cacher;
+
+    public function __construct(
+        ExperimentBranchesRepository $experimentBranchesRepository,
+        Cacher $cacher
+    ) {
+        $this->experimentBranchesRepository = $experimentBranchesRepository;
+        $this->cacher = $cacher;
+    }
+
+    public function getByExperimentAlias(string $experimentAlias): ExperimentBranchesCollection
+    {
+
+        /**
+         * @var ExperimentBranchesCollection $experimentBranches
+         */
+        $experimentBranches = $this->cacher->fetch(
+            $experimentAlias,
+            self::ENTITY_TYPE_EXPERIMENT_BRANCHES,
+            self::EXPIRES_IN_EXPERIMENT_BRANCHES,
+            function () use ($experimentAlias) {
+                return $this->experimentBranchesRepository->getByExperimentAlias($experimentAlias);
+            }
+        );
+
+        return $experimentBranches;
+    }
+
+    public function getBranchIdByUid(string $experimentAlias, string $branchUid): ?string
+    {
+        $branches = $this->getByExperimentAlias($experimentAlias);
+
+        $branchId = null;
+        foreach ($branches->getExperimentBranches() as $branch) {
+            if ($branch->getUid() === $branchUid) {
+                $branchId = $branch->getId();
+            }
+        }
+        if (empty($branchId)) {
+            //todo replace with custom exception
+            throw new \RuntimeException('Branch not found');
+        }
+
+        return $branchId;
+    }
+}

--- a/src/RemoteEntity/Repositories/ExperimentBranchesRepository.php
+++ b/src/RemoteEntity/Repositories/ExperimentBranchesRepository.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\RemoteEntity\Repositories;
+
+use Abrouter\Client\Builders\RequestBuilder;
+use Abrouter\Client\Builders\UrlBuilder;
+use Abrouter\Client\RemoteEntity\Collections\ExperimentBranchesCollection;
+use Abrouter\Client\Config\Accessors\TokenConfigAccessor;
+use Abrouter\Client\Http\RequestExecutor;
+use Abrouter\Client\Transformers\BranchesRequestTransformer;
+
+class ExperimentBranchesRepository
+{
+    /**
+     * @var UrlBuilder $urlBuilder
+     */
+    private UrlBuilder $urlBuilder;
+
+    /**
+     * @var RequestBuilder
+     */
+    private RequestBuilder $requestBuilder;
+
+
+    /**
+     * @var TokenConfigAccessor
+     */
+    private TokenConfigAccessor $tokenConfigAccessor;
+
+    /**
+     * @var RequestExecutor
+     */
+    private RequestExecutor $requestExecutor;
+
+    /**
+     * @var BranchesRequestTransformer
+     */
+    private BranchesRequestTransformer $branchesRequestTransformer;
+
+    public function __construct(
+        UrlBuilder $urlBuilder,
+        RequestBuilder $requestBuilder,
+        TokenConfigAccessor $tokenConfigAccessor,
+        RequestExecutor $requestExecutor,
+        BranchesRequestTransformer $branchesRequestTransformer
+    ) {
+        $this->urlBuilder = $urlBuilder;
+        $this->requestBuilder = $requestBuilder;
+        $this->tokenConfigAccessor = $tokenConfigAccessor;
+        $this->requestExecutor = $requestExecutor;
+        $this->branchesRequestTransformer = $branchesRequestTransformer;
+    }
+
+    public function getByExperimentAlias(string $experimentAlias): ExperimentBranchesCollection
+    {
+        $request = $this->requestBuilder
+            ->get()
+            ->url($this->urlBuilder->fetchBranchesUri($experimentAlias)->build())
+            ->withHeaders([
+                'Authorization' => $this->tokenConfigAccessor->getToken()
+            ])
+            ->build();
+
+        $response = $this->requestExecutor->execute($request);
+
+        return $this->branchesRequestTransformer->transform($response);
+    }
+
+    public function getBranchIdByUid(string $experimentAlias, string $branchUid): ?string
+    {
+        $branches = $this->getByExperimentAlias($experimentAlias);
+        $branchId = null;
+        foreach ($branches->getExperimentBranches() as $branch) {
+            if ($branch->getUid() === $branchUid) {
+                $branchId = $branchUid;
+            }
+        }
+
+        return $branchId;
+    }
+}

--- a/src/RemoteEntity/Repositories/ExperimentUserBranchesRepository.php
+++ b/src/RemoteEntity/Repositories/ExperimentUserBranchesRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\RemoteEntity\Repositories;
+
+use Abrouter\Client\Builders\RequestBuilder;
+use Abrouter\Client\Builders\UrlBuilder;
+use Abrouter\Client\Config\Accessors\TokenConfigAccessor;
+use Abrouter\Client\Http\RequestExecutor;
+use Abrouter\Client\Transformers\ExperimentUsersRequestTransformer;
+
+class ExperimentUserBranchesRepository
+{
+    /**
+     * @var UrlBuilder $urlBuilder
+     */
+    private UrlBuilder $urlBuilder;
+
+    /**
+     * @var RequestBuilder
+     */
+    private RequestBuilder $requestBuilder;
+
+
+    /**
+     * @var TokenConfigAccessor
+     */
+    private TokenConfigAccessor $tokenConfigAccessor;
+
+    /**
+     * @var RequestExecutor
+     */
+    private RequestExecutor $requestExecutor;
+
+    private ExperimentUsersRequestTransformer $experimentUsersRequestTransformer;
+
+    public function __construct(
+        UrlBuilder $urlBuilder,
+        RequestBuilder $requestBuilder,
+        TokenConfigAccessor $tokenConfigAccessor,
+        RequestExecutor $requestExecutor,
+        ExperimentUsersRequestTransformer $experimentUsersRequestTransformer
+    ) {
+        $this->urlBuilder = $urlBuilder;
+        $this->requestBuilder = $requestBuilder;
+        $this->tokenConfigAccessor = $tokenConfigAccessor;
+        $this->requestExecutor = $requestExecutor;
+        $this->experimentUsersRequestTransformer = $experimentUsersRequestTransformer;
+    }
+
+    public function getBranchesByUser(string $userSignature)
+    {
+        $request = $this->requestBuilder
+            ->get()
+            ->url($this->urlBuilder->listExperimentUsersUri($userSignature)->build())
+            ->withHeaders([
+                'Authorization' => $this->tokenConfigAccessor->getToken()
+            ])
+            ->build();
+
+        $response = $this->requestExecutor->execute($request);
+
+        return $this->experimentUsersRequestTransformer->transform($response);
+    }
+}

--- a/src/RemoteEntity/Repositories/UserEventsRepository.php
+++ b/src/RemoteEntity/Repositories/UserEventsRepository.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\RemoteEntity\Repositories;
+
+use Abrouter\Client\Builders\RequestBuilder;
+use Abrouter\Client\Builders\UrlBuilder;
+use Abrouter\Client\Config\Accessors\TokenConfigAccessor;
+use Abrouter\Client\Http\RequestExecutor;
+use Abrouter\Client\Transformers\ExperimentUsersRequestTransformer;
+
+/**
+ * Todo continue working on it
+ */
+class UserEventsRepository
+{
+    /**
+     * @var UrlBuilder $urlBuilder
+     */
+    private UrlBuilder $urlBuilder;
+
+    /**
+     * @var RequestBuilder
+     */
+    private RequestBuilder $requestBuilder;
+
+
+    /**
+     * @var TokenConfigAccessor
+     */
+    private TokenConfigAccessor $tokenConfigAccessor;
+
+    /**
+     * @var RequestExecutor
+     */
+    private RequestExecutor $requestExecutor;
+
+    private ExperimentUsersRequestTransformer $experimentUsersRequestTransformer;
+
+    public function __construct(
+        UrlBuilder $urlBuilder,
+        RequestBuilder $requestBuilder,
+        TokenConfigAccessor $tokenConfigAccessor,
+        RequestExecutor $requestExecutor,
+        ExperimentUsersRequestTransformer $experimentUsersRequestTransformer
+    ) {
+        $this->urlBuilder = $urlBuilder;
+        $this->requestBuilder = $requestBuilder;
+        $this->tokenConfigAccessor = $tokenConfigAccessor;
+        $this->requestExecutor = $requestExecutor;
+        $this->experimentUsersRequestTransformer = $experimentUsersRequestTransformer;
+    }
+}

--- a/src/Requests/RunExperimentRequest.php
+++ b/src/Requests/RunExperimentRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Abrouter\Client\Requests;
@@ -18,22 +19,22 @@ class RunExperimentRequest
      * @var RequestBuilder
      */
     private RequestBuilder $requestBuilder;
-    
+
     /**
      * @var TokenConfigAccessor
      */
     private TokenConfigAccessor $tokenConfigAccessor;
-    
+
     /**
      * @var UrlBuilder
      */
     private UrlBuilder $urlBuilder;
-    
+
     /**
      * @var RequestExecutor
      */
     private RequestExecutor $requestExecutor;
-    
+
     public function __construct(
         TokenConfigAccessor $tokenConfigAccessor,
         RequestBuilder $requestBuilder,
@@ -45,7 +46,7 @@ class RunExperimentRequest
         $this->urlBuilder = $urlBuilder;
         $this->requestExecutor = $requestExecutor;
     }
-    
+
     /**
      * @param JsonPayload $jsonPayload
      *
@@ -64,7 +65,7 @@ class RunExperimentRequest
             ])
             ->withJsonPayload($jsonPayload->getPayload())
             ->build();
-        
+
         try {
             return $this->requestExecutor->execute($request);
         } catch (\Throwable $exception) {

--- a/src/Requests/SendEventRequest.php
+++ b/src/Requests/SendEventRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Abrouter\Client\Requests;
@@ -18,22 +19,22 @@ class SendEventRequest
      * @var RequestBuilder
      */
     private RequestBuilder $requestBuilder;
-    
+
     /**
      * @var TokenConfigAccessor
      */
     private TokenConfigAccessor $tokenConfigAccessor;
-    
+
     /**
      * @var UrlBuilder
      */
     private UrlBuilder $urlBuilder;
-    
+
     /**
      * @var RequestExecutor
      */
     private RequestExecutor $requestExecutor;
-    
+
     public function __construct(
         TokenConfigAccessor $tokenConfigAccessor,
         RequestBuilder $requestBuilder,
@@ -45,7 +46,7 @@ class SendEventRequest
         $this->urlBuilder = $urlBuilder;
         $this->requestExecutor = $requestExecutor;
     }
-    
+
     /**
      * @param JsonPayload $jsonPayload
      *
@@ -64,7 +65,7 @@ class SendEventRequest
             ])
             ->withJsonPayload($jsonPayload->getPayload())
             ->build();
-        
+
         try {
             return $this->requestExecutor->execute($request);
         } catch (\Throwable $exception) {

--- a/src/Services/Experiments/RunOfflineModeProxy.php
+++ b/src/Services/Experiments/RunOfflineModeProxy.php
@@ -1,9 +1,10 @@
 <?php
-declare(strict_types = 1);
 
-namespace Abrouter\Client\Support\Experiments;
+declare(strict_types=1);
 
-use Abrouter\Client\Entities\RunExperiment;
+namespace Abrouter\Client\Services\Experiments;
+
+use Abrouter\Client\RemoteEntity\Entities\ExperimentRanResult;
 use Abrouter\Client\Exceptions\InvalidJsonApiResponseException;
 use Abrouter\Client\Exceptions\RunExperimentRequestException;
 use Abrouter\Client\Manager\ExperimentManager;
@@ -14,7 +15,7 @@ class RunOfflineModeProxy
      * @var ExperimentManager
      */
     private ExperimentManager $experimentManager;
-    
+
     /**
      * OfflineModeProxy constructor.
      *
@@ -24,14 +25,14 @@ class RunOfflineModeProxy
     {
         $this->experimentManager = $experimentManager;
     }
-    
+
     /**
      * @param string $userSignature
      * @param string $experimentId
      * @param string $experimentUid
      * @param string $defaultBranchId
      *
-     * @return RunExperiment
+     * @return ExperimentRanResult
      * @throws InvalidJsonApiResponseException
      */
     public function runOffline(
@@ -43,7 +44,7 @@ class RunOfflineModeProxy
         try {
             return $this->experimentManager->run($userSignature, $experimentId);
         } catch (RunExperimentRequestException $runExperimentRequestException) {
-            return new RunExperiment($defaultBranchId, $experimentUid);
+            return new ExperimentRanResult($defaultBranchId, $experimentUid);
         }
     }
 }

--- a/src/Services/ExperimentsParallelRun/AddUserToBranchTask.php
+++ b/src/Services/ExperimentsParallelRun/AddUserToBranchTask.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Services\ExperimentsParallelRun;
+
+use Abrouter\Client\Contracts\TaskContract;
+
+class AddUserToBranchTask implements TaskContract
+{
+    /**
+     * @var string
+     */
+    private string $experimentId;
+
+    /**
+     * @var string
+     */
+    private string $userSignature;
+
+    /**
+     * @var string
+     */
+    private string $branch;
+
+    private string $experimentAlias;
+
+    public function __construct(string $experimentAlias, string $experimentId, string $userSignature, string $branch)
+    {
+        $this->experimentId = $experimentId;
+        $this->userSignature = $userSignature;
+        $this->branch = $branch;
+        $this->experimentAlias = $experimentAlias;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExperimentId(): string
+    {
+        return $this->experimentId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUserSignature(): string
+    {
+        return $this->userSignature;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBranch(): string
+    {
+        return $this->branch;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExperimentAlias(): string
+    {
+        return $this->experimentAlias;
+    }
+}

--- a/src/Services/ExperimentsParallelRun/ExperimentRunner.php
+++ b/src/Services/ExperimentsParallelRun/ExperimentRunner.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Services\ExperimentsParallelRun;
+
+class ExperimentRunner
+{
+    private $variants;
+
+    public function addSide(string $name, float $percent)
+    {
+        $this->variants[$name] = $percent;
+    }
+
+    public function rollFirst(): string
+    {
+        $firstKey = array_keys($this->variants)[0];
+        return $this->variants[$firstKey];
+    }
+
+    public function roll(): string
+    {
+        $rand = mt_rand(1, 100);
+
+        $start = 0;
+        foreach ($this->variants as $variant => $percent) {
+            if (($rand > $start) && ($rand <= ($start + $percent))) {
+                return $variant;
+            } else {
+                $start = $start + $percent;
+            }
+        }
+
+        $keys = array_keys($this->variants);
+        $version = end($keys);
+        $this->variants = [];
+
+        return $version;
+    }
+}

--- a/src/Services/ExperimentsParallelRun/ParallelRunSwitch.php
+++ b/src/Services/ExperimentsParallelRun/ParallelRunSwitch.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Services\ExperimentsParallelRun;
+
+use Abrouter\Client\Config\Accessors\ParallelRunConfigAccessor;
+
+class ParallelRunSwitch
+{
+    private ParallelRunConfigAccessor $parallelRunConfigAccessor;
+
+    public function __construct(ParallelRunConfigAccessor $parallelRunConfigAccessor)
+    {
+        $this->parallelRunConfigAccessor = $parallelRunConfigAccessor;
+    }
+
+    public function isEnabled(): bool
+    {
+        if (!$this->parallelRunConfigAccessor->isEnabled()) {
+            return false;
+        }
+
+        if ($this->parallelRunConfigAccessor->getKvStorage() === null) {
+            return false;
+        }
+
+        if ($this->parallelRunConfigAccessor->getTaskManager() === null) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Services/ExperimentsParallelRun/ParallelRunner.php
+++ b/src/Services/ExperimentsParallelRun/ParallelRunner.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Services\ExperimentsParallelRun;
+
+use Abrouter\Client\Config\Accessors\ParallelRunConfigAccessor;
+use Abrouter\Client\Contracts\TaskManagerContract;
+use Abrouter\Client\RemoteEntity\Cache\Cacher;
+use Abrouter\Client\RemoteEntity\Entities\ExperimentRanResult;
+use Abrouter\Client\RemoteEntity\Repositories\Cached\ExperimentBranchesCacheRepository;
+
+class ParallelRunner
+{
+    /**
+     * @var ExperimentBranchesCacheRepository
+     */
+    private $experimentBranchesCacheRepository;
+
+    /**
+     * @var ExperimentRunner
+     */
+    private $experimentRunner;
+
+    /**
+     * @var TaskManagerContract
+     */
+    private ?TaskManagerContract $taskManagerContract;
+
+    /**
+     * @var Cacher
+     */
+    private Cacher $cacher;
+
+    public function __construct(
+        ExperimentBranchesCacheRepository $experimentBranchesCacheRepository,
+        ExperimentRunner $experimentRunner,
+        ParallelRunConfigAccessor $parallelRunConfig,
+        Cacher $cacher
+    ) {
+        $this->experimentBranchesCacheRepository = $experimentBranchesCacheRepository;
+        $this->experimentRunner = $experimentRunner;
+        $this->taskManagerContract = $parallelRunConfig->getTaskManager();
+        $this->cacher = $cacher;
+    }
+
+    public function run(string $userSignature, string $experimentAlias): ExperimentRanResult
+    {
+        $runFunction = function () use ($experimentAlias, $userSignature) {
+            $branches = $this
+                ->experimentBranchesCacheRepository
+                ->getByExperimentAlias($experimentAlias);
+
+            foreach ($branches->getExperimentBranches() as $branch) {
+                $this->experimentRunner->addSide($branch->getUid(), (float)$branch->getPercentage());
+            }
+            $branch = $this->experimentRunner->roll();
+
+            $task = new AddUserToBranchTask(
+                $experimentAlias,
+                $branches->getExperimentId(),
+                $userSignature,
+                $branch,
+            );
+
+            $this->taskManagerContract->queue($task);
+
+            return new ExperimentRanResult(
+                $branch,
+                $experimentAlias
+            );
+        };
+
+        /**
+         * @var ExperimentRanResult $ran
+         */
+        $cacheKey = join('', [$experimentAlias, '-', $userSignature]);
+        $ran = $this->cacher->fetch($cacheKey, 'experiment_users', 3600 * 24 * 180, $runFunction);
+
+        return $ran;
+    }
+}

--- a/src/Services/KvStorage/KvStorage.php
+++ b/src/Services/KvStorage/KvStorage.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Services\KvStorage;
+
+use Abrouter\Client\Contracts\KvStorageContract;
+use Abrouter\Client\DB\RedisConnection;
+
+class KvStorage implements KvStorageContract
+{
+    private RedisConnection $redisConnection;
+
+    public function __construct(RedisConnection $redisConnection)
+    {
+        $this->redisConnection = $redisConnection;
+    }
+
+    public function put(string $key, string $value, int $expiresInSeconds = 0): void
+    {
+        if ($expiresInSeconds === 0) {
+            $this->redisConnection->getConnection()->set($key, $value);
+            return ;
+        }
+
+        $this->redisConnection->getConnection()->set($key, $value, 'EX', $expiresInSeconds);
+    }
+
+    public function remove(string $key): void
+    {
+        $this->redisConnection->getConnection()->del($key);
+    }
+
+    public function get(string $key)
+    {
+        return $this->redisConnection->getConnection()->get($key);
+    }
+}

--- a/src/Services/Statistics/SendEventService.php
+++ b/src/Services/Statistics/SendEventService.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Services\Statistics;
+
+use Abrouter\Client\Builders\Payload\EventSendPayloadBuilder;
+use Abrouter\Client\DTO\EventDTO;
+use Abrouter\Client\Entities\SentEvent;
+use Abrouter\Client\Exceptions\InvalidJsonApiResponseException;
+use Abrouter\Client\Exceptions\SendEventRequestException;
+use Abrouter\Client\Requests\SendEventRequest;
+use Abrouter\Client\Transformers\SendEventRequestTransformer;
+
+class SendEventService
+{
+    private SendEventRequest $sendEventRequest;
+
+    private EventSendPayloadBuilder $eventSendPayloadBuilder;
+
+    private SendEventRequestTransformer $sendEventRequestTransformer;
+
+    public function __construct(
+        SendEventRequest $sendEventRequest,
+        EventSendPayloadBuilder $eventSendPayloadBuilder,
+        SendEventRequestTransformer $sendEventRequestTransformer
+    ) {
+        $this->sendEventRequest = $sendEventRequest;
+        $this->eventSendPayloadBuilder = $eventSendPayloadBuilder;
+        $this->sendEventRequestTransformer = $sendEventRequestTransformer;
+    }
+
+    /**
+     * @param EventDTO $eventDTO
+     * @return SentEvent
+     * @throws InvalidJsonApiResponseException
+     * @throws SendEventRequestException
+     */
+    public function sendEvent(EventDTO $eventDTO): SentEvent
+    {
+        $payload = $this->eventSendPayloadBuilder->build($eventDTO);
+        $response = $this->sendEventRequest->sendEvent($payload);
+        $sentEvent = $this->sendEventRequestTransformer->transform($response);
+
+        return $sentEvent;
+    }
+}

--- a/src/Services/Statistics/SendEventTask.php
+++ b/src/Services/Statistics/SendEventTask.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Services\Statistics;
+
+use Abrouter\Client\Contracts\TaskContract;
+use Abrouter\Client\DTO\EventDTO;
+
+class SendEventTask implements TaskContract
+{
+    private EventDTO $eventDTO;
+
+    public function __construct(EventDTO $eventDTO)
+    {
+        $this->eventDTO = $eventDTO;
+    }
+
+    /**
+     * @return EventDTO
+     */
+    public function getEventDTO(): EventDTO
+    {
+        return $this->eventDTO;
+    }
+}

--- a/src/Services/TaskManager/TaskManager.php
+++ b/src/Services/TaskManager/TaskManager.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Services\TaskManager;
+
+use Abrouter\Client\Contracts\TaskContract;
+use Abrouter\Client\Contracts\TaskManagerContract;
+use Abrouter\Client\Events\EventDispatcher;
+
+class TaskManager implements TaskManagerContract
+{
+    private TaskStorage $taskStorage;
+
+    private EventDispatcher $eventDispatcher;
+
+    public function __construct(TaskStorage $taskStorage, EventDispatcher $eventDispatcher)
+    {
+        $this->taskStorage = $taskStorage;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function queue(TaskContract $task): void
+    {
+        $this->taskStorage->publish($task);
+    }
+
+    public function work(int $iterationsLimit = 0): void
+    {
+        $this->taskStorage->subscribe(function (TaskContract $taskContract) {
+            $this->eventDispatcher->dispatch($taskContract, false);
+        }, $iterationsLimit);
+    }
+}

--- a/src/Services/TaskManager/TaskStorage.php
+++ b/src/Services/TaskManager/TaskStorage.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Services\TaskManager;
+
+use Abrouter\Client\Contracts\TaskContract;
+use Abrouter\Client\DB\RedisConnection;
+
+class TaskStorage
+{
+    private const HSET_KEY = 'tasks';
+    private const TASK_INCREMENT = 'task-increment';
+    private const TASK_OFFSET = 'task-offset';
+
+    private RedisConnection $redisConnection;
+
+    public function __construct(RedisConnection $redisConnection)
+    {
+        $this->redisConnection = $redisConnection;
+    }
+
+    public function publish(TaskContract $taskContract)
+    {
+        $connection = $this->redisConnection->getConnection();
+        $taskId = $connection->get(self::TASK_INCREMENT);
+        if ($taskId === null) {
+            $taskId = 1;
+            $connection->set(self::TASK_INCREMENT, $taskId);
+        }
+        $connection->set(self::TASK_INCREMENT, $taskId + 1);
+
+        $connection->hset(self::HSET_KEY, $taskId, serialize($taskContract));
+    }
+
+    public function subscribe(callable $f, int $iterationsLimit = 0)
+    {
+        $counter = 0;
+        while (true) {
+            $counter++;
+            $connection = $this->redisConnection->getConnection();
+            $keys = $connection->hkeys(self::HSET_KEY);
+            $offset = $connection->get(self::TASK_OFFSET) ?? 0;
+            $actualKeys = array_reduce($keys, function (array $acc, string $key) use ($offset) {
+                if ($key > $offset) {
+                    $acc[] = $key;
+                }
+
+                return $acc;
+            }, []);
+            sort($actualKeys);
+
+            array_reduce($actualKeys, function (array $acc, $key) use ($f) {
+                try {
+                    $payload = $this->redisConnection->getConnection()->hget(self::HSET_KEY, $key);
+                    $event = unserialize($payload);
+                    $f($event);
+                } catch (\Throwable $e) {
+                    echo $e->getMessage();
+                }
+
+                $this->redisConnection->getConnection()->set(self::TASK_OFFSET, $key);
+                return $acc;
+            }, []);
+
+            if ($iterationsLimit > 0 && $counter === $iterationsLimit) {
+                break;
+            }
+        }
+    }
+}

--- a/src/Transformers/BranchesRequestTransformer.php
+++ b/src/Transformers/BranchesRequestTransformer.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Transformers;
+
+use Abrouter\Client\RemoteEntity\Collections\ExperimentBranchesCollection;
+use Abrouter\Client\Entities\Client\Response;
+use Abrouter\Client\RemoteEntity\Entities\ExperimentBranch;
+use Abrouter\Client\Exceptions\InvalidJsonApiResponseException;
+use Throwable;
+
+/**
+ * Todo: rename all classes in this dir to *ResponseTransformer
+ */
+class BranchesRequestTransformer
+{
+    /**
+     * @throws InvalidJsonApiResponseException
+     */
+    public function transform(Response $response): ExperimentBranchesCollection
+    {
+        $json = $response->getResponseJson();
+
+        if (empty($json['data'])) {
+            return new ExperimentBranchesCollection();
+        }
+
+        try {
+            $branchesIds = array_reduce(
+                $json['data'][0]['relationships']['branches']['data'],
+                function (array $acc, array $identifier) {
+                    $acc[] = $identifier['id'];
+                    return $acc;
+                },
+                []
+            );
+
+            $experimentId = $json['data'][0]['id'];
+            $experimentAlias = $json['data'][0]['attributes']['uid'];
+
+            $included = $json['included'] ?? [];
+            return new ExperimentBranchesCollection(
+                $experimentId,
+                ...array_reduce(
+                    $included,
+                    function (array $acc, array $include) use ($branchesIds, $experimentId, $experimentAlias) {
+                        if (!in_array($include['id'], $branchesIds, true)) {
+                            return $acc;
+                        }
+
+                        $acc[] = new ExperimentBranch(
+                            $include['id'],
+                            $include['attributes']['uid'],
+                            $include['attributes']['percent'],
+                            $experimentAlias,
+                            $experimentId,
+                        );
+
+                        return $acc;
+                    },
+                    []
+                )
+            );
+        } catch (Throwable $e) {
+            throw new InvalidJsonApiResponseException($e->getMessage());
+        }
+    }
+}

--- a/src/Transformers/ExperimentUsersRequestTransformer.php
+++ b/src/Transformers/ExperimentUsersRequestTransformer.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Transformers;
+
+use Abrouter\Client\Entities\Client\Response;
+use Abrouter\Client\RemoteEntity\Collections\ExperimentUserBranchesCollection;
+use Abrouter\Client\Exceptions\InvalidJsonApiResponseException;
+use Abrouter\Client\RemoteEntity\Entities\ExperimentUserBranch;
+
+/**
+ * Todo: rename all classes in this dir to *ResponseTransformer
+ */
+class ExperimentUsersRequestTransformer
+{
+    /**
+     * @throws InvalidJsonApiResponseException
+     */
+    public function transform(Response $response): ExperimentUserBranchesCollection
+    {
+        $json = $response->getResponseJson();
+
+        if (empty($json['data'])) {
+            return new ExperimentUserBranchesCollection();
+        }
+
+        return new ExperimentUserBranchesCollection(...array_reduce(
+            $json['data'],
+            function (array $acc, array $item) {
+                $acc[] = new ExperimentUserBranch(
+                    $item['attributes']['branch-uid'],
+                    $item['attributes']['experiment-uid']
+                );
+                return $acc;
+            },
+            []
+        ));
+    }
+}

--- a/src/Transformers/RunExperimentRequestTransformer.php
+++ b/src/Transformers/RunExperimentRequestTransformer.php
@@ -1,10 +1,11 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Transformers;
 
 use Abrouter\Client\Entities\Client\Response;
-use Abrouter\Client\Entities\RunExperiment;
+use Abrouter\Client\RemoteEntity\Entities\ExperimentRanResult;
 use Abrouter\Client\Exceptions\InvalidJsonApiResponseException;
 use Art4\JsonApiClient\Exception\Exception;
 use Art4\JsonApiClient\Helper\Parser;
@@ -15,10 +16,10 @@ class RunExperimentRequestTransformer
     /**
      * @param Response $response
      *
-     * @return RunExperiment
+     * @return ExperimentRanResult
      * @throws InvalidJsonApiResponseException
      */
-    public function transform(Response $response): RunExperiment
+    public function transform(Response $response): ExperimentRanResult
     {
         try {
             $jsonApi = Parser::parseResponseString(json_encode($response->getResponseJson()));
@@ -28,8 +29,8 @@ class RunExperimentRequestTransformer
             $attributes = $jsonApi->get('data.attributes');
             $branchUid = $attributes->get('branch-uid');
             $experimentUid = $attributes->get('experiment-uid');
-            
-            return new RunExperiment($branchUid, $experimentUid);
+
+            return new ExperimentRanResult($branchUid, $experimentUid);
         } catch (Exception $e) {
             throw new InvalidJsonApiResponseException($e->getMessage());
         }

--- a/src/Transformers/SendEventRequestTransformer.php
+++ b/src/Transformers/SendEventRequestTransformer.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Transformers;
 

--- a/src/Transformers/UserEventsRequestTransformer.php
+++ b/src/Transformers/UserEventsRequestTransformer.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Transformers;
+
+use Abrouter\Client\Entities\Client\Response;
+use Abrouter\Client\RemoteEntity\Collections\ExperimentUserBranchesCollection;
+use Abrouter\Client\Exceptions\InvalidJsonApiResponseException;
+use Abrouter\Client\RemoteEntity\Entities\ExperimentUserBranch;
+
+/**
+ * Todo continue working on it
+ */
+class UserEventsRequestTransformer
+{
+}

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client;
+
+use Abrouter\Client\Config\Accessors\ParallelRunConfigAccessor;
+use Abrouter\Client\Contracts\TaskManagerContract;
+
+class Worker
+{
+    private TaskManagerContract $taskManager;
+
+    public function __construct(ParallelRunConfigAccessor $parallelRunConfigAccessor)
+    {
+        $this->taskManager = $parallelRunConfigAccessor->getTaskManager();
+    }
+
+    public function work(int $iterationsLimit = 0)
+    {
+        $this->taskManager->work($iterationsLimit);
+    }
+}

--- a/tests/Integration/ABTestParallelRunTest.php
+++ b/tests/Integration/ABTestParallelRunTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Tests\Integration;
+
+use Abrouter\Client\Client;
+use Abrouter\Client\RemoteEntity\Repositories\ExperimentUserBranchesRepository;
+use Abrouter\Client\Services\ExperimentsParallelRun\ParallelRunSwitch;
+use Abrouter\Client\Worker;
+
+class ABTestParallelRunTest extends IntegrationTestCase
+{
+    public function testABTestRun()
+    {
+        $this->configureParallelRun('add73bda37106bbddf2e6b3f61c6ed197c2250e99df9474ad01b9afb2035af33cf66c292fdf6a6e8');
+        $this->clearRedis();
+
+        $client = $this->getContainer()->make(Client::class);
+        $userSignature = 'test-run-f:' . uniqid();
+        $run = $client->experiments()->run($userSignature, 'example_experiment');
+
+        $switch = $this->getContainer()->make(ParallelRunSwitch::class);
+        $this->assertTrue($switch->isEnabled());
+
+        $this->assertTrue(in_array($run->getBranchId(), ['first_branch', 'second_branch']));
+
+        $this->assertTrue($run->getExperimentId() === 'example_experiment');
+
+
+        $experimentUserBranchesRepository = $this->getContainer()->make(ExperimentUserBranchesRepository::class);
+        $experimentUserBranches = $experimentUserBranchesRepository->getBranchesByUser($userSignature);
+        $this->assertEquals(sizeof($experimentUserBranches->getAll()), 0);
+
+        $worker = $this->getContainer()->make(Worker::class);
+        $worker->work(100);
+
+        $experimentUserBranches = $experimentUserBranchesRepository->getBranchesByUser($userSignature);
+        $experimentUserBranch = $experimentUserBranches->getAll()[0];
+
+        $this->assertTrue(in_array($experimentUserBranch->getBranchUid(), ['first_branch', 'second_branch'], true));
+    }
+}

--- a/tests/Integration/ABTestSyncRunTest.php
+++ b/tests/Integration/ABTestSyncRunTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Tests\Integration;
+
+use Abrouter\Client\Client;
+use Abrouter\Client\RemoteEntity\Repositories\ExperimentUserBranchesRepository;
+use Abrouter\Client\Services\ExperimentsParallelRun\ParallelRunSwitch;
+use Abrouter\Client\Worker;
+
+class ABTestSyncRunTest extends IntegrationTestCase
+{
+    public function testABTestRun()
+    {
+        $this->bindConfig(
+            'https://abrouter.com',
+            'add73bda37106bbddf2e6b3f61c6ed197c2250e99df9474ad01b9afb2035af33cf66c292fdf6a6e8'
+        );
+
+        $client = $this->getContainer()->make(Client::class);
+        $userSignature = 'test-run-f:' . uniqid();
+        $run = $client->experiments()->run($userSignature, 'example_experiment');
+
+        $switch = $this->getContainer()->make(ParallelRunSwitch::class);
+        $this->assertFalse($switch->isEnabled());
+
+        $this->assertTrue(in_array($run->getBranchId(), ['first_branch', 'second_branch']));
+
+        $this->assertTrue($run->getExperimentId() === 'example_experiment');
+
+        $experimentUserBranchesRepository = $this->getContainer()->make(ExperimentUserBranchesRepository::class);
+        $experimentUserBranches = $experimentUserBranchesRepository->getBranchesByUser($userSignature);
+        $experimentUserBranch = $experimentUserBranches->getAll()[0];
+
+        $this->assertTrue(in_array($experimentUserBranch->getBranchUid(), ['first_branch', 'second_branch'], true));
+    }
+}

--- a/tests/Integration/Cacher/CacherTest.php
+++ b/tests/Integration/Cacher/CacherTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Tests\Integration\Cacher;
+
+use Abrouter\Client\RemoteEntity\Cache\Cacher;
+use Abrouter\Client\Tests\Integration\IntegrationTestCase;
+
+class CacherTest extends IntegrationTestCase
+{
+    public function testCacher()
+    {
+        $this->configureParallelRun();
+
+        $cacher = $this->getContainer()->make(Cacher::class);
+
+        $obj = new \stdClass();
+        $obj->test = 'test';
+        $value = $cacher->fetch('bla-bla', 'type', 5, function () use ($obj) {
+            return $obj;
+        });
+
+        $this->assertEquals($value, $obj);
+    }
+}

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Tests\Integration;
+
+use Abrouter\Client\Client;
+use Abrouter\Client\Config\Config;
+use Abrouter\Client\Config\ParallelRunConfig;
+use Abrouter\Client\Config\RedisConfig;
+use Abrouter\Client\Contracts\KvStorageContract;
+use Abrouter\Client\DB\RedisConnection;
+use Abrouter\Client\Services\KvStorage\KvStorage;
+use Abrouter\Client\Services\TaskManager\TaskManager;
+use DI\Container;
+use DI\ContainerBuilder;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class IntegrationTestCase extends BaseTestCase
+{
+    private const TEST_HOST = 'https://127.0.0.1';
+
+    /**
+     * @var Container $container
+     */
+    private Container $container;
+
+    /**
+     * @var string $token
+     */
+    private string $token;
+
+    /**
+     * @var string $host
+     */
+    private string $host;
+
+    public function getContainer()
+    {
+        if (isset($this->container)) {
+            return $this->container;
+        }
+
+        $containerBuilder = new ContainerBuilder();
+        $container = $containerBuilder->build();
+        $this->container = $container;
+        return $container;
+    }
+
+    protected function bindConfig(string $host = self::TEST_HOST, string $token = null): void
+    {
+        $this->host = $host;
+        $this->token = $token ?? uniqid();
+
+        $config = new Config($this->token, $this->host);
+        $this->getContainer()->set(Config::class, $config);
+    }
+
+    public function getConfig(): Config
+    {
+        return $this->getContainer()->get(Config::class);
+    }
+
+    protected function configureParallelRun(string $token = null): void
+    {
+        $container = $this->getContainer();
+
+        $redisConfig = new RedisConfig(
+            $_SERVER['REDIS_HOST'] ?? 'redis',
+            6379,
+            '',
+            '',
+            ''
+        );
+
+        $host = 'https://abrouter.com';
+        $token = $token ?? uniqid();
+
+        $config = new Config(
+            $token,
+            $host,
+        );
+        $config->setRedisConfig($redisConfig);
+        $container->set(Config::class, $config);
+
+        $kvStorage = $container->make(KvStorage::class);
+        $container->make(KvStorage::class);
+        $container->set(
+            KvStorageContract::class,
+            $kvStorage
+        );
+
+        $config->setKvStorageConfig($kvStorage);
+        $container->set(Config::class, $config);
+        $taskManager = $container->make(TaskManager::class);
+
+        $config->setParallelRunConfig(new ParallelRunConfig(true, $taskManager));
+    }
+
+    protected function getClient(): Client
+    {
+        return $this->container->make(Client::class);
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    protected function createArgumentsFor(string $class)
+    {
+        $reflection = new \ReflectionClass($class);
+
+        if ($reflection->getConstructor() === null) {
+            return new $class();
+        }
+
+        $argumentsNeeded = $reflection->getConstructor()->getParameters();
+        $arguments = array_reduce($argumentsNeeded, function (array $acc, \ReflectionParameter $reflectionParameter) {
+            try {
+                $acc[] = $this->getContainer()->make($reflectionParameter->getType()->getName());
+            } catch (\Throwable $e) {
+                $acc[] = null;
+            }
+
+            return $acc;
+        }, []);
+
+        return $arguments;
+    }
+
+    protected function clearRedis(): void
+    {
+        $this->getContainer()->make(RedisConnection::class)->getConnection()->flushall();
+    }
+}

--- a/tests/Integration/KvStorage/KvStorageTest.php
+++ b/tests/Integration/KvStorage/KvStorageTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Tests\Integration\KvStorage;
+
+use Abrouter\Client\Config\Config;
+use Abrouter\Client\Tests\Integration\IntegrationTestCase;
+
+class KvStorageTest extends IntegrationTestCase
+{
+    public function testBasic()
+    {
+        $this->configureParallelRun();
+        $this->clearRedis();
+
+        $config = $this->getContainer()->get(Config::class);
+
+        $this->assertNull($config->getKvStorage()->get('zhopa'));
+        $config->getKvStorage()->put('zhopa1', "1vvvq");
+        $this->assertEquals($config->getKvStorage()->get('zhopa1'), "1vvvq");
+        $config->getKvStorage()->remove('zhopa1');
+        $this->assertNull($config->getKvStorage()->get('zhopa1'));
+    }
+
+    public function testExpire()
+    {
+        $this->configureParallelRun();
+        $this->clearRedis();
+
+        $config = $this->getContainer()->get(Config::class);
+
+        $k = 'barebukh';
+        $v = 'qq';
+        $this->assertNull($config->getKvStorage()->get($k));
+        $config->getKvStorage()->put($k, $v, 1);
+        $this->assertEquals($config->getKvStorage()->get($k), $v);
+        sleep(2);
+        $this->assertNull($config->getKvStorage()->get($k));
+    }
+}

--- a/tests/Integration/ParallelRun/ParallelRunSwitchTest.php
+++ b/tests/Integration/ParallelRun/ParallelRunSwitchTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Tests\Integration\ParallelRun;
+
+use Abrouter\Client\Services\ExperimentsParallelRun\ParallelRunSwitch;
+use Abrouter\Client\Tests\Integration\IntegrationTestCase;
+
+class ParallelRunSwitchTest extends IntegrationTestCase
+{
+    public function testSwitchEnabled()
+    {
+        $this->configureParallelRun();
+
+        $switch = $this->getContainer()->make(ParallelRunSwitch::class);
+        $this->assertTrue($switch->isEnabled());
+    }
+
+    public function testSwitchDisabled()
+    {
+        $this->bindConfig();
+
+        $switch = $this->getContainer()->make(ParallelRunSwitch::class);
+        $this->assertFalse($switch->isEnabled());
+    }
+}

--- a/tests/Integration/ParallelRun/TaskManagerTest.php
+++ b/tests/Integration/ParallelRun/TaskManagerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Tests\Integration\ParallelRun;
+
+use Abrouter\Client\Contracts\TaskContract;
+use Abrouter\Client\Events\EventDispatcher;
+use Abrouter\Client\Services\ExperimentsParallelRun\AddUserToBranchTask;
+use Abrouter\Client\Services\TaskManager\TaskManager;
+use Abrouter\Client\Tests\Integration\IntegrationTestCase;
+
+class TaskManagerTest extends IntegrationTestCase
+{
+    public static bool $eventReceived = false;
+
+    public static int $eventCountReceived = 0;
+    public static string $experimentId = '';
+
+    public function testReceiveSingleEvent()
+    {
+        $this->configureParallelRun();
+        $this->clearRedis();
+
+        $args = $this->createArgumentsFor(TaskManager::class);
+        $args[1] = new class (...$this->createArgumentsFor(EventDispatcher::class)) extends EventDispatcher {
+            public function dispatch(TaskContract $taskContract, bool $async = false): void
+            {
+                TaskManagerTest::$eventReceived = true;
+            }
+        };
+        $taskManager = new TaskManager(...$args);
+        $taskManager->queue(new AddUserToBranchTask(uniqid(), uniqid(), uniqid(), uniqid()));
+
+        $taskManager->work(1);
+
+        $this->assertTrue(self::$eventReceived);
+    }
+
+    public function testReceivingTenEvents()
+    {
+        $this->configureParallelRun();
+        $this->clearRedis();
+
+        foreach (range(1, 10) as $k) {
+            $args = $this->createArgumentsFor(TaskManager::class);
+            $args[1] = new class (...$this->createArgumentsFor(EventDispatcher::class)) extends EventDispatcher {
+                public function dispatch(TaskContract $taskContract, $async = false): void
+                {
+                    if (!$taskContract instanceof AddUserToBranchTask) {
+                        return ;
+                    }
+
+                    TaskManagerTest::$eventCountReceived++;
+                    TaskManagerTest::$experimentId = $taskContract->getExperimentId();
+                }
+            };
+            $taskManager = new TaskManager(...$args);
+            $experimentId = uniqid();
+            $taskManager->queue(new AddUserToBranchTask('alias', $experimentId, uniqid(), uniqid()));
+            $taskManager->work(10);
+            $this->assertEquals($experimentId, self::$experimentId);
+            $this->assertTrue(self::$eventCountReceived === $k);
+        }
+    }
+}

--- a/tests/Integration/StatSendParallelTest.php
+++ b/tests/Integration/StatSendParallelTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Tests\Integration;
+
+use Abrouter\Client\Client;
+use Abrouter\Client\DTO\EventDTO;
+
+class StatSendParallelTest extends IntegrationTestCase
+{
+    public function testStatSend()
+    {
+//        $this->configureParallelRun('add73bda37106bbddf2e6b3f61c6ed197c2250e99df9474ad01b9afb2035af33cf66c292fdf6a6e8');
+//        $this->clearRedis();
+//
+//        $client = $this->getContainer()->make(Client::class);
+//        $userSignature = 'test-run-f:' . uniqid();
+//        $client->statistics()->sendEvent(new EventDTO(null, $userSignature, 'event1'));
+    }
+}

--- a/tests/Unit/Builders/ConfigBuilderTest.php
+++ b/tests/Unit/Builders/ConfigBuilderTest.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Tests\Unit\Transformers;
 
@@ -13,22 +14,22 @@ class ConfigBuilderTest extends TestCase
      * @var ConfigBuilder $configBuilder
      */
     private ConfigBuilder $configBuilder;
-    
+
     public function setUp(): void
     {
         $this->configBuilder = $this->getContainer()->make(ConfigBuilder::class);
     }
-    
+
     public function testBuild()
     {
         $host = 'https://example.com';
         $token = uniqid();
-        
+
         $config = $this->configBuilder
             ->setHost($host)
             ->setToken($token)
             ->build();
-        
+
         $this->assertInstanceOf(Config::class, $config);
         $this->assertEquals($config->getToken(), $token);
         $this->assertEquals($config->getHost(), $host);

--- a/tests/Unit/Builders/Payload/EventSendPayloadBuilderTest.php
+++ b/tests/Unit/Builders/Payload/EventSendPayloadBuilderTest.php
@@ -39,7 +39,8 @@ class EventSendPayloadBuilderTest extends TestCase
         );
         $payload = $this->eventSendPayloadBuilder->build($eventDTO);
         $this->assertInstanceOf(JsonPayload::class, $payload);
-        $this->assertEquals($payload->getPayload(),
+        $this->assertEquals(
+            $payload->getPayload(),
             [
                 'data' => [
                     'type' => 'events',

--- a/tests/Unit/Builders/Payload/ExperimentRunPayloadBuilderTest.php
+++ b/tests/Unit/Builders/Payload/ExperimentRunPayloadBuilderTest.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Tests\Unit\Builders\Payload;
 
@@ -13,19 +14,19 @@ class ExperimentRunPayloadBuilderTest extends TestCase
      * @var ExperimentRunPayloadBuilder $experimentRunPayloadBuilder
      */
     private ExperimentRunPayloadBuilder $experimentRunPayloadBuilder;
-    
+
     public function setUp(): void
     {
         $this->experimentRunPayloadBuilder = $this->getContainer()->make(ExperimentRunPayloadBuilder::class);
     }
-    
+
     public function testPayloadIsCorrect()
     {
         $userSignature = uniqid();
         $experimentId = uniqid();
-        
+
         $payload = $this->experimentRunPayloadBuilder->build($userSignature, $experimentId);
-        
+
         $this->assertInstanceOf(JsonPayload::class, $payload);
         $this->assertEquals($payload->getPayload(), [
             'data' => [

--- a/tests/Unit/Builders/RequestBuilderTest.php
+++ b/tests/Unit/Builders/RequestBuilderTest.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Tests\Unit\Transformers;
 
@@ -13,12 +14,12 @@ class RequestBuilderTest extends TestCase
      * @var RequestBuilder $requestBuilder
      */
     private RequestBuilder $requestBuilder;
-    
+
     public function setUp(): void
     {
         $this->requestBuilder = $this->getContainer()->make(RequestBuilder::class);
     }
-    
+
     public function testRequestBuilder()
     {
         $url = '/';
@@ -28,14 +29,14 @@ class RequestBuilderTest extends TestCase
         $headers = [
             'Authorization' => 'Bearer ' . uniqid(),
         ];
-        
+
         $request = $this->requestBuilder
             ->post()
             ->url($url)
             ->withJsonPayload($payload)
             ->withHeaders($headers)
             ->build();
-        
+
         $this->assertInstanceOf(Request::class, $request);
         $this->assertEquals($request->getPayload(), $payload);
         $this->assertEquals($request->getMethod(), RequestBuilder::METHOD_POST);

--- a/tests/Unit/Builders/UrlBuilderTest.php
+++ b/tests/Unit/Builders/UrlBuilderTest.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Tests\Unit\Transformers;
 
@@ -12,13 +13,13 @@ class UrlBuilderTest extends TestCase
      * @var UrlBuilder $urlBuilder
      */
     private UrlBuilder $urlBuilder;
-    
+
     public function setUp(): void
     {
         $this->bindConfig();
         $this->urlBuilder = $this->getContainer()->make(UrlBuilder::class);
     }
-    
+
     public function testUrlBuilderRunExperimentUri()
     {
         $url = $this->urlBuilder->runExperimentUri()->build();

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Abrouter\Client\Tests\Unit\Managers;
+namespace Abrouter\Client\Tests\Unit;
 
 use Abrouter\Client\Client;
 use Abrouter\Client\Manager\ExperimentManager;
@@ -14,13 +14,13 @@ class ClientTest extends TestCase
      * @var Client $client
      */
     private Client $client;
-    
+
     public function setUp(): void
     {
         $this->bindConfig();
         $this->client = $this->getContainer()->make(Client::class);
     }
-    
+
     public function testExperiments()
     {
         $this->assertInstanceOf(ExperimentManager::class, $this->client->experiments());

--- a/tests/Unit/Config/Accessors/HostConfigAccessorTest.php
+++ b/tests/Unit/Config/Accessors/HostConfigAccessorTest.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Tests\Unit\Transformers;
 
@@ -12,13 +13,13 @@ class HostConfigAccessorTest extends TestCase
      * @var HostConfigAccessor $HostConfigAccessor
      */
     private HostConfigAccessor $hostConfigAccessor;
-    
+
     public function setUp(): void
     {
         $this->bindConfig();
         $this->hostConfigAccessor = $this->getContainer()->make(HostConfigAccessor::class);
     }
-    
+
     public function testHostConfigAccessor()
     {
         $this->assertEquals($this->hostConfigAccessor->getHost(), $this->getConfig()->getHost());

--- a/tests/Unit/Config/Accessors/TokenConfigAccessorTest.php
+++ b/tests/Unit/Config/Accessors/TokenConfigAccessorTest.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Tests\Unit\Transformers;
 
@@ -12,13 +13,13 @@ class TokenConfigAccessorTest extends TestCase
      * @var TokenConfigAccessor $tokenConfigAccessor
      */
     private TokenConfigAccessor $tokenConfigAccessor;
-    
+
     public function setUp(): void
     {
         $this->bindConfig();
         $this->tokenConfigAccessor = $this->getContainer()->make(TokenConfigAccessor::class);
     }
-    
+
     public function testHostConfigAccessor()
     {
         $this->assertEquals($this->getConfig()->getToken(), $this->getConfig()->getToken());

--- a/tests/Unit/Config/ConfigTest.php
+++ b/tests/Unit/Config/ConfigTest.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Tests\Unit\Transformers;
 
@@ -12,7 +13,7 @@ class ConfigTest extends TestCase
     {
         $token = uniqid();
         $host = 'https://127.0.0.1';
-        
+
         $config = new Config($token, $host);
         $this->assertEquals($config->getToken(), $token);
         $this->assertEquals($config->getHost(), $host);

--- a/tests/Unit/Entities/Client/RequestTest.php
+++ b/tests/Unit/Entities/Client/RequestTest.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Tests\Unit\Entities\Client;
 
@@ -16,7 +17,7 @@ class RequestTest extends TestCase
         $headers = [
             'Authorization' => 'Bearer ' . uniqid(),
         ];
-        
+
         $jsonPayload = new Request($method, $url, $payload, $headers);
         $this->assertEquals($jsonPayload->getMethod(), $method);
         $this->assertEquals($jsonPayload->getUrl(), $url);

--- a/tests/Unit/Entities/Client/ResponseTest.php
+++ b/tests/Unit/Entities/Client/ResponseTest.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Tests\Unit\Entities\Client;
 
@@ -13,7 +14,7 @@ class ResponseTest extends TestCase
         $expectedResponse = [
             'test' => 1,
         ];
-        
+
         $response = new Response($expectedResponse);
         $this->assertEquals($response->getResponseJson(), $expectedResponse);
     }

--- a/tests/Unit/Entities/JsonPayloadTest.php
+++ b/tests/Unit/Entities/JsonPayloadTest.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Tests\Unit\Entities;
 

--- a/tests/Unit/Entities/RunExperimentTest.php
+++ b/tests/Unit/Entities/RunExperimentTest.php
@@ -1,9 +1,10 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Tests\Unit\Entities;
 
-use Abrouter\Client\Entities\RunExperiment;
+use Abrouter\Client\RemoteEntity\Entities\ExperimentRanResult;
 use Abrouter\Client\Tests\Unit\TestCase;
 
 class RunExperimentTest extends TestCase
@@ -12,8 +13,8 @@ class RunExperimentTest extends TestCase
     {
         $branchId = uniqid();
         $experimentId = uniqid();
-        
-        $runExperiment = new RunExperiment($branchId, $experimentId);
+
+        $runExperiment = new ExperimentRanResult($branchId, $experimentId);
         $this->assertEquals($runExperiment->getExperimentId(), $experimentId);
         $this->assertEquals($runExperiment->getBranchId(), $branchId);
     }

--- a/tests/Unit/Http/RequestExecutorTest.php
+++ b/tests/Unit/Http/RequestExecutorTest.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Tests\Unit\Http;
 
@@ -17,27 +18,27 @@ class RequestExecutorTest extends TestCase
 {
     public function testRequestExecutor()
     {
-        $client = new class() extends Client {
+        $client = new class () extends Client {
             /**
              * @var string
              */
             private string $method;
-    
+
             /**
              * @var string
              */
             private string $url;
-    
+
             /**
              * @var array
              */
             private array $options;
-    
+
             /**
              * @var array
              */
             private array $returnData;
-            
+
             /**
              * @return string
              */
@@ -45,7 +46,7 @@ class RequestExecutorTest extends TestCase
             {
                 return $this->method;
             }
-    
+
             /**
              * @return string
              */
@@ -53,7 +54,7 @@ class RequestExecutorTest extends TestCase
             {
                 return $this->url;
             }
-            
+
             /**
              * @return array
              */
@@ -61,7 +62,7 @@ class RequestExecutorTest extends TestCase
             {
                 return $this->options;
             }
-    
+
             /**
              * @return array
              */
@@ -69,7 +70,7 @@ class RequestExecutorTest extends TestCase
             {
                 return $this->returnData;
             }
-    
+
             /**
              * @param array $returnData
              */
@@ -77,17 +78,17 @@ class RequestExecutorTest extends TestCase
             {
                 $this->returnData = $returnData;
             }
-    
+
             public function request($method, $uri = '', array $options = []): ResponseInterface
             {
                 $this->method = $method;
                 $this->url = $uri;
                 $this->options = $options;
-                
+
                 return new Response(200, [], json_encode($this->returnData));
             }
         };
-        
+
         $client->setReturnData([
             'data' => [
                 'type' => 'response-type',
@@ -97,7 +98,7 @@ class RequestExecutorTest extends TestCase
             ]
         ]);
         $requestExecutorMock = new RequestExecutor($client);
-        
+
         $request = new Request(
             RequestBuilder::METHOD_POST,
             '/',
@@ -110,10 +111,10 @@ class RequestExecutorTest extends TestCase
                 ]
             ],
             [
-                'Authorization' => 'Bearer '. uniqid(),
+                'Authorization' => 'Bearer ' . uniqid(),
             ]
         );
-        
+
         $response = $requestExecutorMock->execute($request);
         $this->assertInstanceOf(AbrResponseInterface::class, $response);
         $this->assertEquals($response->getResponseJson(), $client->getReturnData());

--- a/tests/Unit/Managers/FeatureToggleManagerTest.php
+++ b/tests/Unit/Managers/FeatureToggleManagerTest.php
@@ -7,6 +7,7 @@ use Abrouter\Client\Entities\Client\Response;
 use Abrouter\Client\Entities\Client\ResponseInterface;
 use Abrouter\Client\Entities\JsonPayload;
 use Abrouter\Client\Manager\FeatureFlagManager;
+use Abrouter\Client\RemoteEntity\Cache\Cacher;
 use Abrouter\Client\Tests\Unit\TestCase;
 use Abrouter\Client\Requests\RunFeatureFlagRequest;
 use Abrouter\Client\Transformers\RunFeatureFlagRequestTransformer;
@@ -15,6 +16,8 @@ class FeatureToggleManagerTest extends TestCase
 {
     public function testRunFeatureFlag()
     {
+        $this->bindConfig();
+
         $runFeatureFlagRequest = new class () extends RunFeatureFlagRequest {
             public function __construct()
             {
@@ -34,12 +37,10 @@ class FeatureToggleManagerTest extends TestCase
             }
         };
 
+        $arguments = $this->createArgumentsFor(FeatureFlagManager::class);
+        $arguments[0] = $runFeatureFlagRequest;
 
-        $experimentManager = new FeatureFlagManager(
-            $runFeatureFlagRequest,
-            $this->getContainer()->make(FeatureFlagRunPayloadBuilder::class),
-            $this->getContainer()->make(RunFeatureFlagRequestTransformer::class),
-        );
+        $experimentManager = new FeatureFlagManager(...$arguments);
         $id = uniqid();
         $runFeatureFlagEntity = $experimentManager->run($id);
 

--- a/tests/Unit/Support/Experiments/RunOfflineModeProxyTest.php
+++ b/tests/Unit/Support/Experiments/RunOfflineModeProxyTest.php
@@ -1,15 +1,18 @@
 <?php
-declare(strict_types = 1);
 
-namespace Abrouter\Client\Tests\Unit\Support\Experiments;
+declare(strict_types=1);
+
+namespace Abrouter\Client\Tests\Unit\Services\Experiments;
 
 use Abrouter\Client\Builders\Payload\ExperimentRunPayloadBuilder;
-use Abrouter\Client\Entities\RunExperiment;
+use Abrouter\Client\RemoteEntity\Entities\ExperimentRanResult;
 use Abrouter\Client\Exceptions\InvalidJsonApiResponseException;
 use Abrouter\Client\Exceptions\RunExperimentRequestException;
 use Abrouter\Client\Manager\ExperimentManager;
 use Abrouter\Client\Requests\RunExperimentRequest;
-use Abrouter\Client\Support\Experiments\RunOfflineModeProxy;
+use Abrouter\Client\Services\Experiments\RunOfflineModeProxy;
+use Abrouter\Client\Services\ExperimentsParallelRun\ParallelRunner;
+use Abrouter\Client\Services\ExperimentsParallelRun\ParallelRunSwitch;
 use Abrouter\Client\Tests\Unit\TestCase;
 use Abrouter\Client\Transformers\RunExperimentRequestTransformer;
 
@@ -19,33 +22,37 @@ class RunOfflineModeProxyTest extends TestCase
      * @var ExperimentManager
      */
     private ExperimentManager $experimentManager;
-    
+
     /**
      * @var RunOfflineModeProxy
      */
     private RunOfflineModeProxy $runOfflineModeProxy;
-    
+
     public function setUp(): void
     {
         $this->bindConfig();
-        
+
         $runExperimentRequest = $this->getContainer()->make(RunExperimentRequest::class);
         $experimentRunPayloadBuilder = $this->getContainer()->make(ExperimentRunPayloadBuilder::class);
         $runExperimentRequestTransformer = $this->getContainer()->make(RunExperimentRequestTransformer::class);
-        
+        $parallelRunSwitch = $this->getContainer()->make(ParallelRunSwitch::class);
+        $parallelRunner = $this->getContainer()->make(ParallelRunner::class);
+
         $this->experimentManager = new class (
             $runExperimentRequest,
             $experimentRunPayloadBuilder,
-            $runExperimentRequestTransformer
+            $runExperimentRequestTransformer,
+            $parallelRunSwitch,
+            $parallelRunner
         ) extends ExperimentManager {
-            public function run(string $userSignature, string $experimentUid): RunExperiment
+            public function run(string $userSignature, string $experimentUid): ExperimentRanResult
             {
                 throw new RunExperimentRequestException('cURL error 6: Could not resolve host: abrouter.com');
             }
         };
         $this->runOfflineModeProxy = new RunOfflineModeProxy($this->experimentManager);
     }
-    
+
     /**
      * @throws InvalidJsonApiResponseException
      */
@@ -53,9 +60,9 @@ class RunOfflineModeProxyTest extends TestCase
     {
         $defaultBranch = uniqid();
         $experimentUid = uniqid();
-        
+
         $runExperiment = $this->runOfflineModeProxy->runOffline(uniqid(), uniqid(), $experimentUid, $defaultBranch);
-        
+
         $this->assertEquals($runExperiment->getExperimentId(), $experimentUid);
         $this->assertEquals($runExperiment->getBranchId(), $defaultBranch);
     }

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Tests\Unit;
 
@@ -11,45 +12,70 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 class TestCase extends BaseTestCase
 {
     private const TEST_HOST = 'https://127.0.0.1';
-    
+
     /**
      * @var Container $container
      */
     private Container $container;
-    
+
     /**
      * @var string $token
      */
     private string $token;
-    
+
     /**
      * @var string $host
      */
     private string $host;
-    
+
     public function getContainer()
     {
         if (isset($this->container)) {
             return $this->container;
         }
-    
+
         $containerBuilder = new ContainerBuilder();
         $container = $containerBuilder->build();
         $this->container = $container;
         return $container;
     }
-    
+
     protected function bindConfig(): void
     {
         $this->host = self::TEST_HOST;
         $this->token = uniqid();
-        
+
         $config = new Config($this->token, $this->host);
         $this->getContainer()->set(Config::class, $config);
     }
-    
+
     public function getConfig(): Config
     {
         return $this->getContainer()->get(Config::class);
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    protected function createArgumentsFor(string $class)
+    {
+        $reflection = new \ReflectionClass($class);
+
+        if ($reflection->getConstructor() === null) {
+            return new $class();
+        }
+
+        $argumentsNeeded = $reflection->getConstructor()->getParameters();
+        $arguments = array_reduce($argumentsNeeded, function (array $acc, \ReflectionParameter $reflectionParameter) {
+            try {
+                $acc[] = $this->getContainer()->make($reflectionParameter->getType()->getName());
+            } catch (\Throwable $e) {
+                $acc[] = null;
+            }
+
+            return $acc;
+        }, []);
+
+        return $arguments;
     }
 }

--- a/tests/Unit/Transformers/BranchesRequestTransformerTest.php
+++ b/tests/Unit/Transformers/BranchesRequestTransformerTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abrouter\Client\Tests\Unit\Transformers;
+
+use Abrouter\Client\Entities\Client\Response;
+use Abrouter\Client\Exceptions\InvalidJsonApiResponseException;
+use Abrouter\Client\RemoteEntity\Collections\ExperimentBranchesCollection;
+use Abrouter\Client\Tests\Unit\TestCase;
+use Abrouter\Client\Transformers\BranchesRequestTransformer;
+
+class BranchesRequestTransformerTest extends TestCase
+{
+    /**
+     * @var BranchesRequestTransformer
+     */
+    private $branchesRequestTransformer;
+
+    public function setUp(): void
+    {
+        $this->branchesRequestTransformer = $this->getContainer()->make(BranchesRequestTransformer::class);
+    }
+
+    /**
+     * @throws InvalidJsonApiResponseException
+     */
+    public function testTransform()
+    {
+        $responseJson = [
+            'data' => [
+                0 => [
+                    'id' => '8F761000-0000-0000-0000C828',
+                    'type' => 'experiments',
+                    'attributes' => [
+                        'name' => 'price',
+                        'uid' => 'price',
+                        'alias' => 'price',
+                        'config' => [
+                        ],
+                        'is_enabled' => true,
+                        'is_feature_toggle' => false,
+                    ],
+                    'relationships' => [
+                        'owner' => [
+                            'data' => [
+                                'id' => '8538A000-0000-0000-00005B7D',
+                                'type' => 'users',
+                            ],
+                        ],
+                        'branches' => [
+                            'data' => [
+                                0 => [
+                                    'id' => '2A7C2000-0000-0000-00005D3D',
+                                    'type' => 'experiment_branches',
+                                ],
+                                1 => [
+                                    'id' => 'A62D3000-0000-0000-00005D3D',
+                                    'type' => 'experiment_branches',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'meta' => [
+                'token' => '',
+            ],
+            'included' => [
+                0 => [
+                    'id' => '2A7C2000-0000-0000-00005D3D',
+                    'type' => 'experiment_branches',
+                    'attributes' => [
+                        'name' => 'low',
+                        'uid' => 'low',
+                        'percent' => 50,
+                        'config' => [
+                        ],
+                    ],
+                    'relationships' => [
+                        'experiment' => [
+                            'data' => [
+                                'id' => '8F761000-0000-0000-0000C828',
+                                'type' => 'users',
+                            ],
+                        ],
+                    ],
+                ],
+                1 => [
+                    'id' => 'A62D3000-0000-0000-00005D3D',
+                    'type' => 'experiment_branches',
+                    'attributes' => [
+                        'name' => 'original',
+                        'uid' => 'original',
+                        'percent' => 50,
+                        'config' => [
+                        ],
+                    ],
+                    'relationships' => [
+                        'experiment' => [
+                            'data' => [
+                                'id' => '8F761000-0000-0000-0000C828',
+                                'type' => 'users',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $experimentBranchesCollection = $this->branchesRequestTransformer->transform(new Response($responseJson));
+
+        $expId = '8F761000-0000-0000-0000C828';
+        $this->assertInstanceOf(ExperimentBranchesCollection::class, $experimentBranchesCollection);
+        $this->assertEquals($experimentBranchesCollection->getExperimentId(), $expId);
+        $this->assertEquals(sizeof($experimentBranchesCollection->getExperimentBranches()), 2);
+
+        $this->assertEquals($experimentBranchesCollection->getExperimentBranches()[0]->getUid(), 'low');
+        $this->assertEquals($experimentBranchesCollection->getExperimentBranches()[0]->getPercentage(), 50);
+        $this->assertEquals($experimentBranchesCollection->getExperimentBranches()[0]->getExperimentId(), $expId);
+        $this->assertEquals(
+            $experimentBranchesCollection->getExperimentBranches()[0]->getId(),
+            '2A7C2000-0000-0000-00005D3D',
+        );
+
+        $this->assertEquals($experimentBranchesCollection->getExperimentBranches()[1]->getUid(), 'original');
+        $this->assertEquals($experimentBranchesCollection->getExperimentBranches()[1]->getPercentage(), 50);
+        $this->assertEquals($experimentBranchesCollection->getExperimentBranches()[1]->getExperimentId(), $expId);
+        $this->assertEquals(
+            $experimentBranchesCollection->getExperimentBranches()[1]->getId(),
+            'A62D3000-0000-0000-00005D3D',
+        );
+    }
+
+    /**
+     * @throws InvalidJsonApiResponseException
+     */
+    public function testEmptyResponse()
+    {
+        $t = $this->branchesRequestTransformer->transform(new Response([
+            'data' => [
+            ],
+        ]));
+
+        $this->assertNull($t->getExperimentId());
+        $this->assertEquals(sizeof($t->getExperimentBranches()), 0);
+    }
+
+
+    /**
+     * @throws InvalidJsonApiResponseException
+     */
+    public function testException()
+    {
+        $this->expectException(InvalidJsonApiResponseException::class);
+        $this->branchesRequestTransformer->transform(new Response([
+            'data' => [
+                [
+                    'id' => 'test',
+                ]
+            ],
+        ]));
+    }
+}

--- a/tests/Unit/Transformers/RunExperimentTransformerTest.php
+++ b/tests/Unit/Transformers/RunExperimentTransformerTest.php
@@ -1,10 +1,11 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace Abrouter\Client\Tests\Unit\Transformers;
 
 use Abrouter\Client\Entities\Client\Response;
-use Abrouter\Client\Entities\RunExperiment;
+use Abrouter\Client\RemoteEntity\Entities\ExperimentRanResult;
 use Abrouter\Client\Tests\Unit\TestCase;
 use Abrouter\Client\Transformers\RunExperimentRequestTransformer;
 use Abrouter\Client\Exceptions\InvalidJsonApiResponseException;
@@ -15,12 +16,12 @@ class RunExperimentTransformerTest extends TestCase
      * @var RunExperimentRequestTransformer $runExperimentRequestTransformer
      */
     private RunExperimentRequestTransformer $runExperimentRequestTransformer;
-    
+
     public function setUp(): void
     {
         $this->runExperimentRequestTransformer = $this->getContainer()->make(RunExperimentRequestTransformer::class);
     }
-    
+
     /**
      * @throws InvalidJsonApiResponseException
      */
@@ -28,7 +29,7 @@ class RunExperimentTransformerTest extends TestCase
     {
         $branchUid = uniqid();
         $experimentUid = uniqid();
-        
+
         $runExperiment = $this->runExperimentRequestTransformer->transform(new Response([
             'data' => [
                 'type' => 'experiment_branch_users',
@@ -39,12 +40,12 @@ class RunExperimentTransformerTest extends TestCase
                 ],
             ],
         ]));
-        
-        $this->assertInstanceOf(RunExperiment::class, $runExperiment);
+
+        $this->assertInstanceOf(ExperimentRanResult::class, $runExperiment);
         $this->assertEquals($runExperiment->getBranchId(), $branchUid);
         $this->assertEquals($runExperiment->getExperimentId(), $experimentUid);
     }
-    
+
     /**
      * @throws InvalidJsonApiResponseException
      */

--- a/worker/tests/worker_tests.php
+++ b/worker/tests/worker_tests.php
@@ -1,0 +1,61 @@
+<?php
+
+use Abrouter\Client\Config\Config;
+use Abrouter\Client\Config\ParallelRunConfig;
+use Abrouter\Client\Config\RedisConfig;
+use Abrouter\Client\Contracts\KvStorageContract;
+use Abrouter\Client\Services\KvStorage\KvStorage;
+use Abrouter\Client\Services\TaskManager\TaskManager;
+use DI\ContainerBuilder;
+
+require '/app/vendor/autoload.php';
+
+$containerBuilder = new ContainerBuilder();
+$container = $containerBuilder->build();
+
+
+$container->set(
+    RedisConfig::class,
+    new RedisConfig(
+        $_SERVER['REDIS_HOST'] ?? 'redis',
+        6379,
+        '',
+        '',
+        ''
+    )
+);
+
+$host = 'https://abrouter.com';
+$token = uniqid();
+
+$config = new Config(
+    $token,
+    $host,
+);
+$container->set(Config::class, $config);
+
+$kvStorage = $container->make(KvStorage::class);
+$container->make(KvStorage::class);
+$container->set(
+    KvStorageContract::class,
+    $kvStorage
+);
+
+$config->setKvStorageConfig($kvStorage);
+$container->set(Config::class, $config);
+$taskManager = $container->make(TaskManager::class);
+
+$config->setParallelRunConfig(new ParallelRunConfig(true, $taskManager));
+
+
+/**
+ * @var Config $containerConfig
+ */
+$containerConfig = $container->get(Config::class);
+
+
+/**
+ * @var TaskManager $taskManager
+ */
+$taskManager = $container->make(TaskManager::class);
+$taskManager->work();

--- a/worker/worker.conf
+++ b/worker/worker.conf
@@ -1,0 +1,11 @@
+program:worker-queue]
+command=php worker.php --tries=1 --timeout=0
+process_name=%(program_name)s-%(process_num)s
+numprocs=1
+autostart=true
+autorestart=true
+stopsignal=KILL
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/worker/worker.php
+++ b/worker/worker.php
@@ -1,0 +1,6 @@
+<?php
+
+require '../vendor/autoload.php';
+
+//configure the client
+//Call Worker::work()


### PR DESCRIPTION
Add parallel run and caching

Caching:
1. Feature flags
2. Experiments running

A parallel run was added to:
1. Running of the experiments. 
2. Statistics


Common features:
TaskManager - built-in but replaceable via contract task manager for async running.  Uses Redis by default. Storing all tasks and offset for PHP worker.
KvStorage - built-in but also replaceable vi contract key-value storage. Our implementation uses Redis.
